### PR TITLE
API 문서화 및 시큐리티 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,10 +44,13 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    # Rest docs를 이용해 문서화
+    - name: Build Rest Docs
+      run: ./gradlew :module-api:copyDocument
+
     # gradle Jib를 이용해 이미지를 만들고 원격 저장소에 Push
     - name: Setup Jib with Gradle
       run: ./gradlew :module-api:jib
-
 
     # ssh로 접속해 재배포
     - name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 *.ipr
 out/
 !**/src/main/**/out/
+!**/src/docs
 !**/src/test/**/out/
 
 ### Eclipse ###

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ build/
 *.ipr
 out/
 !**/src/main/**/out/
-!**/src/docs
 !**/src/test/**/out/
+!**/src/resources/**
 
 ### Eclipse ###
 .apt_generated

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -3,6 +3,7 @@ import java.text.SimpleDateFormat
 plugins {
     id 'java'
     id 'com.google.cloud.tools.jib' version '3.3.1'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 jib {
@@ -23,15 +24,42 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    asciidoctorExt
+}
+
 dependencies {
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     implementation project(':module-core')
     implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation project(':module-core')
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 test {
     useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    configurations 'asciidoctorExt'
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file("src/main/resources/static/docs")
+}
+
+task copyDocument(type: Copy){
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
 }

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 dependencies {
     implementation project(':module-core')
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation project(':module-core')

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -1,0 +1,14 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+
+== 카테고리 목록
+=== Request
+include::{snippets}/categories/http-request.adoc[]
+
+
+=== Response
+include::{snippets}/categories/http-response.adoc[]

--- a/module-api/src/main/java/com/codingbottle/common/config/SwaggerConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/config/SwaggerConfig.java
@@ -1,0 +1,142 @@
+package com.codingbottle.common.config;
+
+import com.codingbottle.common.model.ErrorResponseDto;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@Component
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Helfy API Document")
+                .version("v0.0.1")
+                .description("Helfy 문서")
+                .contact(new Contact().name("WanF-Project").url("https://github.com/codingBottle/Helfy-SERVER"))
+                .license(new License().name("MIT License").url("https://github.com/codingBottle/Helfy-SERVER/blob/main/LICENSE"));
+
+        String authName = "Firebase token";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(authName);
+        Components components = new Components()
+                .addSecuritySchemes(
+                        authName,
+                        new SecurityScheme()
+                                .name(authName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("Bearer")
+                                .bearerFormat("Firebase")
+                                .description("Access Token(Firebase Token) 토큰을 입력해주세요.(Bearer 붙이지 않아도 됩니다~)")
+                );
+
+        Map<String, ApiResponse> responses = getResponses();
+
+        for (String key : responses.keySet()) {
+            components.addResponses(key, responses.get(key));
+        }
+
+        Server prodServer = new Server();
+
+        prodServer.description("Production Server")
+                .url("https://helfy-server.duckdns.org");
+
+        Server devServer = new Server();
+
+        devServer.description("Development Server")
+                .url("http://localhost:8080");
+
+        return new OpenAPI()
+                .addSecurityItem(securityRequirement)
+                .components(components)
+                .info(info)
+                .servers(Arrays.asList(prodServer, devServer));
+    }
+
+    private Map<String, ApiResponse> getResponses() {
+        ApiResponse noContent, badRequest, unauthorized, forbidden, notFound, conflict, internalServerError;
+        var schema = ModelConverters.getInstance()
+                .resolveAsResolvedSchema(new AnnotatedType(ErrorResponseDto.class)).schema;
+
+        noContent = new ApiResponse()
+                .description("데이터 없음")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(null)
+                        )
+                );
+
+        badRequest = new ApiResponse()
+                .description("잘못된 요청입니다.")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(schema)
+                        )
+                );
+
+        unauthorized = new ApiResponse()
+                .description("인증을 할 수 없습니다.(토큰 없음, 만료된 토큰, 잘못된 토큰 ...)")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(schema)
+                        )
+                );
+
+        forbidden = new ApiResponse()
+                .description("접근할 수 없습니다.")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(schema)
+                        )
+                );
+
+        notFound = new ApiResponse()
+                .description("데이터를 찾을 수 없습니다.")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(schema)
+                        )
+                );
+
+        conflict = new ApiResponse()
+                .description("서버의 현재 상태와 요청이 충돌 상태입니다.")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(schema)
+                        )
+                );
+
+        internalServerError = new ApiResponse()
+                .description("서버 오류(관리자 문의)")
+                .content(new Content()
+                        .addMediaType("application/json",
+                                new MediaType().schema(schema)
+                        )
+                );
+
+        return Map.of(
+                "204", noContent,
+                "400", badRequest,
+                "401", unauthorized,
+                "403", forbidden,
+                "404", notFound,
+                "409", conflict,
+                "500", internalServerError
+        );
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/category/controller/CategoryController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/category/controller/CategoryController.java
@@ -1,6 +1,8 @@
 package com.codingbottle.domain.category.controller;
 
 import com.codingbottle.domain.category.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,12 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
+@Tag(name = "카테고리", description = "카테고리 API")
 @RestController
 @RequiredArgsConstructor
 public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping("/categories")
+    @Operation(summary = "카테고리 목록 조회")
     public ResponseEntity<Map<String, String>> findAll() {
         Map<String, String> categories = categoryService.findAll();
 

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -30,3 +30,17 @@ spring:
       name: user
       password: 1234
 
+springdoc:
+  packages-to-scan: com.codingbottle
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    tags-sorter: method
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs/json
+    groups:
+      enabled: true
+  cache:
+    disabled: true
+

--- a/module-api/src/test/java/com/codingbottle/docs/config/RestDocsConfig.java
+++ b/module-api/src/test/java/com/codingbottle/docs/config/RestDocsConfig.java
@@ -1,0 +1,17 @@
+package com.codingbottle.docs.config;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@TestConfiguration
+public class RestDocsConfig {
+    @Bean
+    public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcBuilderCustomizer() {
+        return configurer -> configurer.operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint());
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/docs/util/ApiDocumentUtils.java
+++ b/module-api/src/test/java/com/codingbottle/docs/util/ApiDocumentUtils.java
@@ -1,0 +1,20 @@
+package com.codingbottle.docs.util;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+public interface ApiDocumentUtils {
+    static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                modifyUris()
+                        .scheme("https")
+                        .host("helfy-server.duckdns.org")
+                , prettyPrint());
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint());
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/category/controller/CategoryControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,73 @@
+package com.codingbottle.domain.category.controller;
+
+import com.codingbottle.docs.config.RestDocsConfig;
+import com.codingbottle.domain.category.entity.Category;
+import com.codingbottle.domain.category.service.CategoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CategoryController 테스트")
+@ContextConfiguration(classes = CategoryController.class)
+@WebMvcTest(value = CategoryController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+@AutoConfigureRestDocs
+@Import(RestDocsConfig.class)
+class CategoryControllerTest {
+    MockMvc mvc;
+
+    @MockBean
+    CategoryService categoryService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context,
+               RestDocumentationContextProvider provider) {
+        this.mvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(provider))
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회")
+    void find_all_categories() throws Exception {
+        //given
+        List<Category> categoryList = Arrays.asList(Category.values());
+
+        Map<String, String> categories = categoryList.stream()
+                .collect(Collectors.toMap(Category::name, Category::getDetail));
+
+        given(categoryService.findAll()).willReturn(categories);
+        //when & then
+        mvc.perform(get("/categories"))
+                .andExpect(status().isOk())
+                .andDo(document("categories",
+                        getDocumentRequest(),
+                        getDocumentResponse()));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/category/service/CategoryServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,27 @@
+package com.codingbottle.domain.category.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("CategoryService 테스트")
+class CategoryServiceTest {
+    CategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        categoryService = new CategoryService();
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회")
+    void find_all_categories() {
+        // given & when
+        var categories = categoryService.findAll();
+
+        // then
+        assertThat(categories).isNotEmpty();
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/common/config/SecurityConfig.java
+++ b/module-core/src/main/java/com/codingbottle/common/config/SecurityConfig.java
@@ -8,11 +8,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final UserDetailService userDetailService;
@@ -21,18 +25,23 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest()
-                        .authenticated())
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize ->
+                        authorize.anyRequest()
+                                .authenticated())
                 .addFilterBefore(firebaseTokenFilter(), UsernamePasswordAuthenticationFilter.class)
-                .sessionManagement(sessionManagement -> sessionManagement
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .exceptionHandling(exceptionHandling -> exceptionHandling
-                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .build();
     }
 
     @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return webSecurity -> webSecurity.ignoring().requestMatchers("/docs/**","/api-docs/**", "/swagger-ui/**","/favicon.ico");
+    }
+
     public FirebaseTokenFilter firebaseTokenFilter() {
         return new FirebaseTokenFilter(userDetailService, firebaseAuth);
     }


### PR DESCRIPTION
## :sparkles: 이슈 번호:  #16 


## :bulb: 상세 내용:
* swagger를 이용하여 API 테스트용 문서를 생성 (경로: http://localhost:8080/swagger-ui/index.html)
* rest docs를 이용하여 API 안내 문서를 생성 (경로: http://localhost:8080/docs/index.html)
* security에 api 문서 경로를 필터 검증 대상에서 제외하도록 설정
* git action에 rest docs를 빌드하는 workflow 추가
* 기존의 만들어져 있던 category api 문서화
## Swagger - API 테스트 용
<img width="1496" alt="swagger" src="https://github.com/codingBottle/Helfy-SERVER/assets/77445491/df8a2480-4c3c-4b49-8dc7-d4c3a95bddf1">

## Rest docs - API 설명 및 요청, 응답 값 확인용
<img width="1498" alt="rest docs" src="https://github.com/codingBottle/Helfy-SERVER/assets/77445491/4610a7cc-6f9c-4747-ab8c-5ae092e94dce">

