### PR TITLE
AWS S3를 이용한 Image API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects { subproject ->
 
     dependencies {
         compileOnly 'org.projectlombok:lombok'
+        implementation  'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation group: 'com.google.firebase', name: 'firebase-admin', version: '8.0.1'

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -4,11 +4,25 @@
 :toc: left
 :toclevels: 3
 
+= API 문서
 
-== 카테고리 목록
-=== Request
-include::{snippets}/categories/http-request.adoc[]
+[[API-개요]]
 
+[[오류-응답]]
+== 오류 응답
+operation::error-response[snippets='response-body,response-fields']
 
-=== Response
-include::{snippets}/categories/http-response.adoc[]
+[[카테고리-API]]
+== 카테고리 API
+
+[[카테고리-목록]]
+=== 카테고리 목록
+operation::categories-list[snippets='http-request,http-response']
+
+[[이미지-API]]
+== 이미지 API
+
+[[이미지-업로드]]
+=== 이미지 업로드
+operation::images-upload[snippets='http-request,request-parts,query-parameters,http-response,response-fields']
+

--- a/module-api/src/main/java/com/codingbottle/domain/Image/controller/ImageController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/Image/controller/ImageController.java
@@ -1,0 +1,27 @@
+package com.codingbottle.domain.Image.controller;
+
+import com.codingbottle.domain.Image.entity.Directory;
+import com.codingbottle.domain.Image.entity.Image;
+import com.codingbottle.domain.Image.model.ImageResponse;
+import com.codingbottle.domain.Image.service.ImageService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "이미지", description = "이미지 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ImageController {
+    private final ImageService imageService;
+
+    @PostMapping(value = "/images", consumes = "multipart/form-data")
+    public ResponseEntity<ImageResponse> imageUpload(@RequestParam("directory") Directory directory,
+                                                     @RequestPart("image") MultipartFile image) {
+        Image upload = imageService.upload(image, directory);
+
+        return ResponseEntity.ok(ImageResponse.of(upload));
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/Image/model/ImageResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/Image/model/ImageResponse.java
@@ -1,0 +1,18 @@
+package com.codingbottle.domain.Image.model;
+
+import com.codingbottle.domain.Image.entity.Image;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public record ImageResponse(
+         Long imageId,
+         String imageUrl
+) {
+    public static ImageResponse of(Image image) {
+        return ImageResponse.builder()
+                .imageId(image.getId())
+                .imageUrl(image.getImageUrl())
+                .build();
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/Image/service/ImageService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/Image/service/ImageService.java
@@ -1,0 +1,102 @@
+package com.codingbottle.domain.Image.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.codingbottle.common.exception.ApplicationErrorException;
+import com.codingbottle.domain.Image.entity.Directory;
+import com.codingbottle.domain.Image.entity.Image;
+import com.codingbottle.domain.Image.repo.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import static com.codingbottle.common.exception.ApplicationErrorType.*;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final AmazonS3Client amazonS3Client;
+    private final ImageRepository imageRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    @Value("${cloudfront-domain-name}")
+    private String CLOUD_FRONT_DOMAIN_NAME;
+
+
+
+    @Transactional
+    public Image upload(MultipartFile multipartFile, Directory directory) {
+        validateImage(multipartFile.getContentType());
+
+        String fileName = createFileName(multipartFile.getOriginalFilename(), directory.getName());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            uploadToBucket(fileName, inputStream, multipartFile.getSize(), multipartFile.getContentType());
+
+            Image image = createImageEntity(fileName, directory);
+
+            return saveImage(image);
+        } catch (IOException e) {
+            throw new ApplicationErrorException(FAIL_TO_UPLOAD_IMAGE, "파일 업로드 중 오류가 발생했습니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Image findById(Long imageId) {
+        return imageRepository.findById(imageId).orElseThrow(() -> new ApplicationErrorException(IMAGE_NOT_FOUND, "해당 이미지를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public void delete(Image image) {
+        amazonS3Client.deleteObject(bucket, image.getDirectory().getName() + "/" + image.getConvertImageName());
+
+        imageRepository.deleteById(image.getId());
+    }
+
+
+
+    private void uploadToBucket(String fileName, InputStream inputStream,
+                                long size,String contentType) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(size);
+        objectMetadata.setContentType(contentType);
+
+        PutObjectRequest putObjectRequest =
+                new PutObjectRequest(bucket, fileName,inputStream ,objectMetadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead);
+
+        amazonS3Client.putObject(putObjectRequest);
+    }
+
+    private Image createImageEntity(String fileName,Directory directory){
+        String path = amazonS3Client.getUrl(bucket, fileName).getPath();
+        return Image.builder()
+                .imageUrl(CLOUD_FRONT_DOMAIN_NAME + path)
+                .directory(directory)
+                .convertImageName(fileName.substring(fileName.lastIndexOf("/") + 1))
+                .build();
+    }
+
+    private Image saveImage(Image image){
+        return imageRepository.save(image);
+    }
+
+    private String createFileName(String fileName, String dirName) {
+        return dirName + "/" + UUID.randomUUID() + "_" + fileName;
+    }
+
+    private void validateImage(String contentType) {
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new ApplicationErrorException(INVALID_FILE_TYPE);
+        }
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/category/controller/CategoryController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/category/controller/CategoryController.java
@@ -6,12 +6,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 @Tag(name = "카테고리", description = "카테고리 API")
 @RestController
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class CategoryController {
     private final CategoryService categoryService;

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -29,7 +29,24 @@ spring:
     user:
       name: user
       password: 1234
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: helfy-bucket
+    stack:
+      auto: false
+
+cloudfront-domain-name: https://d2zp5u7z0buhfu.cloudfront.net
 springdoc:
   packages-to-scan: com.codingbottle
   default-consumes-media-type: application/json;charset=UTF-8

--- a/module-api/src/test/java/com/codingbottle/docs/error/ErrorController.java
+++ b/module-api/src/test/java/com/codingbottle/docs/error/ErrorController.java
@@ -1,0 +1,16 @@
+package com.codingbottle.docs.error;
+
+import com.codingbottle.common.model.ErrorResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/error")
+public class ErrorController {
+    @GetMapping
+    public ResponseEntity<ErrorResponseDto> error() {
+        return ResponseEntity.badRequest().body(ErrorResponseDto.of("오류 코드", "오류 이유"));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/docs/error/ErrorControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/docs/error/ErrorControllerTest.java
@@ -1,0 +1,32 @@
+package com.codingbottle.docs.error;
+
+import com.codingbottle.docs.util.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.getDocumentResponse;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@DisplayName("Error Response")
+@ContextConfiguration(classes = ErrorController.class)
+@WebMvcTest(value = ErrorController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+public class ErrorControllerTest extends RestDocsTest {
+    @Test
+    @DisplayName("에러 응답")
+    void error_response() throws Exception {
+        //when & then
+        mvc.perform(get("/error"))
+                .andDo(document("error-response",
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("reason").description("에러 이유")
+                        )));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/docs/util/ApiDocumentUtils.java
+++ b/module-api/src/test/java/com/codingbottle/docs/util/ApiDocumentUtils.java
@@ -1,8 +1,11 @@
 package com.codingbottle.docs.util;
 
+import org.springframework.restdocs.headers.RequestHeadersSnippet;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
 public interface ApiDocumentUtils {
@@ -11,10 +14,17 @@ public interface ApiDocumentUtils {
                 modifyUris()
                         .scheme("https")
                         .host("helfy-server.duckdns.org")
+                        .removePort()
                 , prettyPrint());
     }
 
     static OperationResponsePreprocessor getDocumentResponse() {
         return preprocessResponse(prettyPrint());
+    }
+
+    static RequestHeadersSnippet getAuthorizationHeader(){
+        return requestHeaders(
+                headerWithName("Authorization").description("Bearer Token")
+        );
     }
 }

--- a/module-api/src/test/java/com/codingbottle/docs/util/RestDocsTest.java
+++ b/module-api/src/test/java/com/codingbottle/docs/util/RestDocsTest.java
@@ -1,0 +1,39 @@
+package com.codingbottle.docs.util;
+
+import com.codingbottle.docs.config.RestDocsConfig;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Disabled
+@ExtendWith(RestDocumentationExtension.class)
+@AutoConfigureRestDocs
+@Import(RestDocsConfig.class)
+public class RestDocsTest {
+    protected MockMvc mvc;
+    protected ObjectMapper objectMapper;
+    @BeforeEach
+    void setUp(WebApplicationContext context,
+               RestDocumentationContextProvider provider) {
+        this.mvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(provider))
+                .alwaysDo(print())
+                .build();
+    }
+
+    protected String createJson(Object dto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(dto);
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/Image/controller/ImageControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/Image/controller/ImageControllerTest.java
@@ -1,0 +1,74 @@
+package com.codingbottle.domain.Image.controller;
+
+import com.codingbottle.docs.util.RestDocsTest;
+import com.codingbottle.domain.Image.entity.Directory;
+import com.codingbottle.domain.Image.entity.Image;
+import com.codingbottle.domain.Image.service.ImageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("ImageController 테스트")
+@ContextConfiguration(classes = ImageController.class)
+@WebMvcTest(value = ImageController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class ImageControllerTest extends RestDocsTest {
+    @MockBean
+    ImageService imageService;
+
+    @Test
+    @DisplayName("이미지 업로드")
+    void image_upload() throws Exception {
+        //given
+        MockMultipartFile mockMultipartFile = new MockMultipartFile(
+                "image",
+                "image.png",
+                "multipart/form-data",
+                "image.png".getBytes(StandardCharsets.UTF_8));
+
+        given(imageService.upload(mockMultipartFile, Directory.POST)).willReturn(Image.builder()
+                .id(1L)
+                .imageUrl("https://d2zp5u7z0buhfu.cloudfront.net/swagger.png")
+                .build());
+        //when & then
+        mvc.perform(multipart("/api/v1/images")
+                        .file(mockMultipartFile)
+                        .header("Authorization", "Bearer FirebaseToken")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .queryParam("directory", "POST"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("imageId").value(1L))
+                .andExpect(jsonPath("imageUrl").value("https://d2zp5u7z0buhfu.cloudfront.net/swagger.png"))
+                .andDo(document("images-upload",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        queryParameters(
+                                parameterWithName("directory")
+                                        .description("이미지 디렉토리(POST, INFORMATION, QUIZ)")
+                        ),
+                        requestParts(
+                                partWithName("image").description("이미지 파일 (png, jpg, jpeg)")
+                        ),
+                        responseFields(
+                                fieldWithPath("imageId").description("이미지 식별자"),
+                                fieldWithPath("imageUrl").description("이미지 URL"))));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/category/controller/CategoryControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/category/controller/CategoryControllerTest.java
@@ -1,23 +1,14 @@
 package com.codingbottle.domain.category.controller;
 
-import com.codingbottle.docs.config.RestDocsConfig;
+import com.codingbottle.docs.util.RestDocsTest;
 import com.codingbottle.domain.category.entity.Category;
 import com.codingbottle.domain.category.service.CategoryService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,31 +18,15 @@ import java.util.stream.Collectors;
 import static com.codingbottle.docs.util.ApiDocumentUtils.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("CategoryController 테스트")
 @ContextConfiguration(classes = CategoryController.class)
-@WebMvcTest(value = CategoryController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
-@ExtendWith(RestDocumentationExtension.class)
-@AutoConfigureRestDocs
-@Import(RestDocsConfig.class)
-class CategoryControllerTest {
-    MockMvc mvc;
-
+@WebMvcTest(value = CategoryControllerTest.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class CategoryControllerTest extends RestDocsTest {
     @MockBean
     CategoryService categoryService;
-
-    @BeforeEach
-    void setUp(WebApplicationContext context,
-               RestDocumentationContextProvider provider) {
-        this.mvc = MockMvcBuilders.webAppContextSetup(context)
-                .apply(documentationConfiguration(provider))
-                .alwaysDo(print())
-                .build();
-    }
 
     @Test
     @DisplayName("카테고리 목록 조회")
@@ -64,10 +39,12 @@ class CategoryControllerTest {
 
         given(categoryService.findAll()).willReturn(categories);
         //when & then
-        mvc.perform(get("/categories"))
+        mvc.perform(get("/api/v1/categories")
+                        .header("Authorization", "Bearer FirebaseToken"))
                 .andExpect(status().isOk())
-                .andDo(document("categories",
+                .andDo(document("categories-list",
                         getDocumentRequest(),
-                        getDocumentResponse()));
+                        getDocumentResponse(),
+                        getAuthorizationHeader()));
     }
 }

--- a/module-core/src/main/java/com/codingbottle/common/config/S3Config.java
+++ b/module-core/src/main/java/com/codingbottle/common/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.codingbottle.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
@@ -10,11 +10,14 @@ public enum ApplicationErrorType {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값이 올바르지 않습니다."),
     INVALID_HEADER(HttpStatus.BAD_REQUEST, "Header 값이 올바르지 않습니다."),
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST, "Firebase 토큰이 올바르지 않습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "파일 타입이 올바르지 않습니다."),
     //401
     NO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     //404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
     //500
+    FAIL_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패하였습니다"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시만 기달려주세요.");
 
     @Getter

--- a/module-core/src/main/java/com/codingbottle/common/exception/GlobalExceptionHandler.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.codingbottle.common.exception;
 
 import com.codingbottle.common.model.ErrorResponseDto;
 import com.google.api.pathtemplate.ValidationException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.context.annotation.Primary;
@@ -10,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+
+import java.io.IOException;
 
 @Slf4j
 @Primary
@@ -27,6 +28,13 @@ public class GlobalExceptionHandler {
         log.error("ValidationException {}", e.getMessage());
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(ApplicationErrorType.VALIDATION_ERROR.name(), e.getMessage());
         return new ResponseEntity<>(errorResponseDto, ApplicationErrorType.VALIDATION_ERROR.getHttpStatus());
+    }
+
+    @ExceptionHandler(value = IOException.class)
+    public ResponseEntity<ErrorResponseDto> handleIOException(WebRequest request, IOException e) {
+        log.error("IOException {}", e.getMessage());
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(ApplicationErrorType.INTERNAL_ERROR.name(), e.getMessage());
+        return new ResponseEntity<>(errorResponseDto, ApplicationErrorType.INTERNAL_ERROR.getHttpStatus());
     }
 
     @ExceptionHandler(value = ConstraintViolationException.class)

--- a/module-core/src/main/java/com/codingbottle/common/model/ErrorResponseDto.java
+++ b/module-core/src/main/java/com/codingbottle/common/model/ErrorResponseDto.java
@@ -4,4 +4,7 @@ public record ErrorResponseDto(
         String errorCode,
         String reason
 ) {
+    public static ErrorResponseDto of(String errorCode, String reason) {
+        return new ErrorResponseDto(errorCode, reason);
+    }
 }

--- a/module-core/src/main/java/com/codingbottle/domain/Image/entity/Directory.java
+++ b/module-core/src/main/java/com/codingbottle/domain/Image/entity/Directory.java
@@ -1,0 +1,14 @@
+package com.codingbottle.domain.Image.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Directory {
+    POST("posts"),INFORMATION("information"), QUIZ("quiz");
+
+    private final String name;
+
+    Directory(String name) {
+        this.name = name;
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/Image/entity/Image.java
+++ b/module-core/src/main/java/com/codingbottle/domain/Image/entity/Image.java
@@ -1,0 +1,33 @@
+package com.codingbottle.domain.Image.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "image")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "directory", nullable = false)
+    private Directory directory;
+
+    @Column(name = "convert_image_name", nullable = false)
+    private String convertImageName;
+
+
+    public Image(String imageUrl, Directory directory, String convertImageName) {
+        this.imageUrl = imageUrl;
+        this.directory = directory;
+        this.convertImageName = convertImageName;
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/Image/repo/ImageRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/Image/repo/ImageRepository.java
@@ -1,0 +1,9 @@
+package com.codingbottle.domain.Image.repo;
+
+import com.codingbottle.domain.Image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}


### PR DESCRIPTION
## :sparkles: 이슈 번호: #15 


## :bulb: 상세 내용:
* AWS S3를 이용한 이미지 업로드 구현(이미지 삭제와 조회는 서비스 계층까지만 구현 추후 필요하면 컨트롤러 작성 예정)
* Rest Docs를 이용한 Image API 문서화
* 오류 응답 API 문서에 추가