### PR TITLE
날씨 API 구현 및 API 연동

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -31,6 +31,8 @@ configurations {
 dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     implementation project(':module-core')
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.1.0'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.2'
     implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     testImplementation platform('org.junit:junit-bom:5.9.1')

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -37,3 +37,9 @@ operation::regions-list[snippets='http-request,http-response']
 === 사용자 지역 변경
 operation::update-user-region[snippets='http-request,query-parameters,http-response,response-fields']
 
+[[날씨-API]]
+== 날씨 API
+
+[[날씨-조회]]
+=== 현재 날씨 조회
+operation::current-weather[snippets='http-request,http-response,response-fields']

--- a/module-api/src/main/java/com/codingbottle/common/config/RedisConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.codingbottle.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(RedisSerializer.string());
+        return redisTemplate;
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/common/config/SchedulingConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.codingbottle.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/module-api/src/main/java/com/codingbottle/common/config/WebClientConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/config/WebClientConfig.java
@@ -1,0 +1,39 @@
+package com.codingbottle.common.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+    @Value("${openweathermap.api-url}")
+    private String openWeatherMapUrl;
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                .responseTimeout(Duration.ofMillis(10000))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(10000, TimeUnit.MILLISECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(10000, TimeUnit.MILLISECONDS)));
+
+        return WebClient.builder()
+                .baseUrl(openWeatherMapUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+}

--- a/module-api/src/main/java/com/codingbottle/common/redis/RedisService.java
+++ b/module-api/src/main/java/com/codingbottle/common/redis/RedisService.java
@@ -20,7 +20,7 @@ public class RedisService {
         String mapperK = writeKeyAsString(key);
         var mapperV = objectMapper.writeValueAsString(value);
 
-        redisTemplate.opsForValue().set(mapperK, mapperV, 3600000, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set(mapperK, mapperV);
     }
 
     public WeatherResponse getObjectValues(Region key) throws JsonProcessingException {

--- a/module-api/src/main/java/com/codingbottle/common/redis/RedisService.java
+++ b/module-api/src/main/java/com/codingbottle/common/redis/RedisService.java
@@ -1,0 +1,36 @@
+package com.codingbottle.common.redis;
+
+import com.codingbottle.domain.region.entity.Region;
+import com.codingbottle.domain.weather.model.WeatherResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void setObjectValues(Region key, WeatherResponse value) throws JsonProcessingException {
+        String mapperK = writeKeyAsString(key);
+        var mapperV = objectMapper.writeValueAsString(value);
+
+        redisTemplate.opsForValue().set(mapperK, mapperV, 3600000, TimeUnit.MILLISECONDS);
+    }
+
+    public WeatherResponse getObjectValues(Region key) throws JsonProcessingException {
+        String mapperK = writeKeyAsString(key);
+        String value = redisTemplate.opsForValue().get(mapperK);
+
+        return objectMapper.readValue(value, WeatherResponse.class);
+    }
+
+    private String writeKeyAsString(Region key) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(key);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/region/controller/RegionController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/region/controller/RegionController.java
@@ -3,7 +3,7 @@ package com.codingbottle.domain.region.controller;
 import com.codingbottle.auth.entity.User;
 import com.codingbottle.domain.region.entity.Region;
 import com.codingbottle.domain.region.service.RegionService;
-import com.codingbottle.domain.user.dto.UserResponse;
+import com.codingbottle.domain.user.model.UserResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/module-api/src/main/java/com/codingbottle/domain/user/model/UserResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/user/model/UserResponse.java
@@ -1,4 +1,4 @@
-package com.codingbottle.domain.user.dto;
+package com.codingbottle.domain.user.model;
 
 import com.codingbottle.auth.entity.User;
 import com.codingbottle.domain.region.entity.Region;

--- a/module-api/src/main/java/com/codingbottle/domain/weather/controller/WeatherController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/weather/controller/WeatherController.java
@@ -1,0 +1,27 @@
+package com.codingbottle.domain.weather.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.weather.model.WeatherResponse;
+import com.codingbottle.domain.weather.service.WeatherService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "날씨", description = "날씨 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class WeatherController {
+    private final WeatherService weatherService;
+
+    @GetMapping("/weather")
+    public ResponseEntity<WeatherResponse> getCurrentWeather(@AuthenticationPrincipal User user) {
+        WeatherResponse weather = weatherService.getWeather(user);
+
+        return ResponseEntity.ok(weather);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/weather/model/CurrentWeatherRequest.java
+++ b/module-api/src/main/java/com/codingbottle/domain/weather/model/CurrentWeatherRequest.java
@@ -1,0 +1,25 @@
+package com.codingbottle.domain.weather.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record CurrentWeatherRequest(
+        @JsonProperty("weather") List<Weather> weather,
+        @JsonProperty("main") WeatherMain main
+) {
+    public record WeatherMain(
+            @JsonProperty("temp")
+            Double temp,
+            @JsonProperty("humidity")
+            Integer humidity
+    ) {
+    }
+
+    public record Weather(
+            @JsonProperty("id")
+            String id
+    ) {
+    }
+}
+

--- a/module-api/src/main/java/com/codingbottle/domain/weather/model/WeatherResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/weather/model/WeatherResponse.java
@@ -1,0 +1,17 @@
+package com.codingbottle.domain.weather.model;
+
+import com.codingbottle.domain.weather.entity.WeatherCode;
+
+public record WeatherResponse(
+        WeatherCode weatherCode,
+        Double temp,
+        Integer humidity
+) {
+    public static WeatherResponse of(CurrentWeatherRequest currentWeatherRequest) {
+        return new WeatherResponse(
+                WeatherCode.of(currentWeatherRequest.weather().get(0).id()),
+                currentWeatherRequest.main().temp(),
+                currentWeatherRequest.main().humidity()
+        );
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/weather/service/WeatherService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/weather/service/WeatherService.java
@@ -1,0 +1,86 @@
+package com.codingbottle.domain.weather.service;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.exception.ApplicationErrorException;
+import com.codingbottle.common.exception.ApplicationErrorType;
+import com.codingbottle.common.redis.RedisService;
+import com.codingbottle.domain.region.entity.Region;
+import com.codingbottle.domain.weather.model.CurrentWeatherRequest;
+import com.codingbottle.domain.weather.model.WeatherResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import javax.annotation.PostConstruct;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+    private final WebClient webClient;
+    private final RedisService redisService;
+
+    @Value("${openweathermap.api-key}")
+    private String weatherApiKey;
+
+    public WeatherResponse getWeather(User user) {
+        try {
+            return redisService.getObjectValues(user.getRegion());
+        } catch (JsonProcessingException e) {
+            throw new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR, "날씨 정보를 가져오는데 실패했습니다.");
+        }
+    }
+
+    @Scheduled(cron = "0 0 0/1 * * *")
+    public void getAllRegionWeather() {
+        Arrays.stream(Region.values())
+                .forEach(this::setAllRegionWeather);
+
+        log.info("Updated all region weather.");
+    }
+
+    private void setAllRegionWeather(Region region) {
+        try {
+            redisService.setObjectValues(region, getWeather(region));
+        } catch (JsonProcessingException e) {
+            throw new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR, "날씨 정보를 가져오는데 실패했습니다.");
+        }
+    }
+
+    private WeatherResponse getWeather(Region region) {
+        CurrentWeatherRequest currentWeatherRequest = getRequestCurrentWeather(region);
+
+        if (currentWeatherRequest == null) {
+            throw new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR, "날씨 정보를 가져오는데 실패했습니다.");
+        }
+
+        return WeatherResponse.of(currentWeatherRequest);
+    }
+
+    private CurrentWeatherRequest getRequestCurrentWeather(Region region) {
+        return webClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("lat", region.getLatitude())
+                        .queryParam("lon", region.getLongitude())
+                        .queryParam("appid", weatherApiKey)
+                        .queryParam("units", "metric")
+                        .queryParam("lang", "kr")
+                        .build())
+                .retrieve()
+                .bodyToMono(CurrentWeatherRequest.class)
+                .block();
+    }
+
+    @PostConstruct
+    private void initAllRegionWeather() {
+        getAllRegionWeather();
+    }
+}
+

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -35,6 +35,10 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 cloud:
   aws:
@@ -63,6 +67,11 @@ springdoc:
       enabled: true
   cache:
     disabled: true
+
+openweathermap:
+  api-key: ${WEATHER_API_KEY}
+  api-url: https://api.openweathermap.org/data/2.5/weather
+
 
 logging:
   slack:

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -39,6 +39,9 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+      lettuce:
+        pool:
+          max-active: 8
 
 cloud:
   aws:

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -37,8 +37,8 @@ spring:
       max-request-size: 10MB
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 cloud:
   aws:

--- a/module-api/src/test/java/com/codingbottle/domain/weather/controller/WeatherControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/weather/controller/WeatherControllerTest.java
@@ -1,0 +1,60 @@
+package com.codingbottle.domain.weather.controller;
+
+import com.codingbottle.docs.util.RestDocsTest;
+import com.codingbottle.domain.weather.entity.WeatherCode;
+import com.codingbottle.domain.weather.model.WeatherResponse;
+import com.codingbottle.domain.weather.service.WeatherService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("WeatherController 테스트")
+@ContextConfiguration(classes = WeatherController.class)
+@WebMvcTest(value = WeatherController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class WeatherControllerTest extends RestDocsTest {
+    @MockBean
+    WeatherService weatherService;
+
+    @Test
+    @DisplayName("사용자 지역의 날씨 조회")
+    void get_current_weather() throws Exception {
+        //given
+        WeatherResponse weatherResponse = new WeatherResponse(WeatherCode.CLEAR, 20.0, 90);
+
+        given(weatherService.getWeather(any())).willReturn(weatherResponse);
+        //when & then
+        mvc.perform(get("/api/v1/weather")
+                        .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("current-weather",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader()
+                        , responseFields(
+                                fieldWithPath("weatherCode").description("날씨 코드 예시: " +
+                                        Arrays.stream(WeatherCode.values())
+                                                .map(Enum::name)
+                                                .collect(Collectors.joining(", "))),
+                                fieldWithPath("temp").description("온도"),
+                                fieldWithPath("humidity").description("습도")
+                        )));
+    }
+
+
+
+}

--- a/module-api/src/test/java/com/codingbottle/domain/weather/service/WeatherServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/weather/service/WeatherServiceTest.java
@@ -1,0 +1,44 @@
+package com.codingbottle.domain.weather.service;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.redis.RedisService;
+import com.codingbottle.domain.region.entity.Region;
+import com.codingbottle.domain.weather.entity.WeatherCode;
+import com.codingbottle.domain.weather.model.WeatherResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WeatherServiceTest {
+    @InjectMocks
+    WeatherService weatherService;
+
+    @Mock
+    RedisService redisService;
+
+    @Test
+    @DisplayName("해당 지역 날씨 정보 조회")
+    void get_weather() throws JsonProcessingException {
+        // given
+        WeatherResponse mockWeatherResponse = new WeatherResponse(WeatherCode.ATMOSPHERE, 20.0, 10);
+
+        given(redisService.getObjectValues(any(Region.class))).willReturn(mockWeatherResponse);
+
+        User user = User.builder()
+                .region(Region.SEOUL)
+                .build();
+        // when
+        WeatherResponse weatherResponse = weatherService.getWeather(user);
+        // then
+        assertThat(weatherResponse).isEqualTo(mockWeatherResponse);
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/region/entity/Region.java
+++ b/module-core/src/main/java/com/codingbottle/domain/region/entity/Region.java
@@ -4,30 +4,34 @@ import lombok.Getter;
 
 @Getter
 public enum Region {
-    SEOUL("서울", 1),
-    GYEONGGI("경기", 2),
-    INCHEON("인천", 3),
-    BUSAN("부산", 4),
-    JEJU("제주", 5),
-    ULSAN("울산", 6),
-    GYEONGSANGNAM("경남", 7),
-    DAEGU("대구", 8),
-    GYEONGSANGBUK("경북", 9),
-    GANGWON("강원", 10),
-    DAEJEON("대전", 11),
-    CHUNGCHEONGNAM("충남", 12),
-    CHUNGCHEONGBUK("충북", 13),
-    SEJONG("세종", 14),
-    GWANGJU("광주", 15),
-    JEOLANAM("전남", 16),
-    JEOLABUK("전북", 17),
-    NONE("미정", 18);
+    SEOUL("서울", 1, 37.5665, 126.9780),
+    GYEONGGI("경기", 2, 37.4138, 127.5183),
+    INCHEON("인천", 3, 37.4563, 126.7052),
+    BUSAN("부산", 4, 35.1796, 129.0756),
+    JEJU("제주", 5, 33.4996, 126.5312),
+    ULSAN("울산", 6, 35.5384, 129.3114),
+    GYEONGSANGNAM("경남", 7, 35.4606, 128.2132),
+    DAEGU("대구", 8, 35.8714, 128.6014),
+    GYEONGSANGBUK("경북", 9, 36.4919, 128.8889),
+    GANGWON("강원", 10, 37.8228, 128.1555),
+    DAEJEON("대전", 11, 36.3504, 127.3845),
+    CHUNGCHEONGNAM("충남", 12, 36.6588, 126.6728),
+    CHUNGCHEONGBUK("충북", 13, 36.6357, 127.4912),
+    SEJONG("세종", 14, 36.4801, 127.2892),
+    GWANGJU("광주", 15, 35.1601, 126.8514),
+    JEOLANAM("전남", 16, 34.8166, 126.4629),
+    JEOLABUK("전북", 17, 35.7175, 127.1530),
+    NONE("미정", 18, 37.5665, 126.9780);
 
     private final String detail;
     private final int code;
+    private final double latitude;
+    private final double longitude;
 
-    Region(String detail, int code) {
+    Region(String detail, int code, double latitude, double longitude) {
         this.detail = detail;
         this.code = code;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/module-core/src/main/java/com/codingbottle/domain/weather/entity/WeatherCode.java
+++ b/module-core/src/main/java/com/codingbottle/domain/weather/entity/WeatherCode.java
@@ -1,0 +1,34 @@
+package com.codingbottle.domain.weather.entity;
+
+import java.util.Arrays;
+
+public enum WeatherCode {
+    THUNDERSTORM("2"),
+    DRIZZLE("3"),
+    RAIN("5"),
+    SNOW("6"),
+    ATMOSPHERE("7"),
+    CLEAR("8"),
+    CLOUDS("9");
+
+    private final String code;
+    WeatherCode(String code) {
+        this.code = code;
+    }
+
+    public static WeatherCode of(String id) {
+        if(isClouds(id)){
+            id = "900";
+        }
+
+        String code = id.substring(0, 1);
+        return Arrays.stream(values())
+                .filter(weatherCode -> weatherCode.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 날씨 코드가 없습니다."));
+    }
+
+    private static boolean isClouds(String id) {
+        return id.startsWith("801") || id.startsWith("802") || id.startsWith("803") || id.startsWith("804");
+    }
+}


### PR DESCRIPTION
## :sparkles: 이슈 번호: #22


## :bulb: 상세 내용: 
- OpenWeatherMap의 오픈 API를 이용하여 날씨 정보를 수집
- Redis를 이용하여 날씨 정보를 DB에 저장하지 않고 빠르게 조회할 수 있도록 함
- Spring Scheduling을 사용하여 1시간마다 날씨 정보를 업데이트하도록 함
- WebFlux를 이용하여 OpenWeatherMap 제공하는 API를 이용하였음
- Region에 좌표를 추가하여 해당 지역의 날씨를 조회할 수 있도록 변경
