### PR TITLE
로깅 전략 수정

### DIFF
--- a/module-core/src/main/java/com/codingbottle/common/security/filter/FirebaseTokenFilter.java
+++ b/module-core/src/main/java/com/codingbottle/common/security/filter/FirebaseTokenFilter.java
@@ -35,7 +35,6 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
         String header = request.getHeader("Authorization");
 
         if (isInvalidHeader(header)) {
-            log.error("requestURL: {}, Invalid header: {}", request.getRequestURI(), header);
             handleFirebaseError(response, ApplicationErrorType.INVALID_HEADER);
             return;
         }
@@ -50,7 +49,6 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
             authenticateUser(user);
 
         } catch (FirebaseAuthException e) {
-            log.error("requestURL: {}, Invalid FirebaseToken: {}", request.getRequestURI(), header);
             handleFirebaseError(response, ApplicationErrorType.INVALID_FIREBASE_TOKEN);
             return;
         }
@@ -67,6 +65,7 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
             user = userService.updateByUsername(firebaseToken);
         } catch (ApplicationErrorException e) {
             user = userService.create(firebaseToken, Role.ROLE_USER);
+            log.debug("Create User: {}", user);
         }
         return user;
     }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #38 


## :bulb: 상세 내용:
- 기존에는 인증되지 않은 사용자의 정보도 로그로 남겼으나 이는 자체 로그인 시스템이 없는 서비스에는 필요없다고 생각
- 따라서 인증된 사용자에 대한 정보를 로그로 남기고 최초 사용자에 대한 정보도 로그를 남김

