### PR TITLE
랜덤 퀴즈 조회 API 구성

### DIFF
--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -66,3 +66,14 @@ operation::delete-post[snippets='http-request,path-parameters,http-response']
 [[날씨-조회]]
 === 현재 날씨 조회
 operation::current-weather[snippets='http-request,http-response,response-fields']
+
+[[퀴즈-API]]
+== 퀴즈 API
+
+[[퀴즈-조회]]
+=== 퀴즈 조회(오늘의 퀴즈, 랜덤 퀴즈 풀어보기)
+operation::quiz-list[snippets='http-request,query-parameters,http-response,response-fields']
+
+[[틀린퀴즈-조회]]
+=== 틀린 퀴즈 조회 (만약 틀린 문제가 없으면 오류 응답)
+operation::wrong-answer-list[snippets='http-request,http-response,response-fields']

--- a/module-api/src/main/java/com/codingbottle/domain/post/controller/PostController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/controller/PostController.java
@@ -2,8 +2,8 @@ package com.codingbottle.domain.post.controller;
 
 import com.codingbottle.auth.entity.User;
 import com.codingbottle.domain.post.entity.Post;
-import com.codingbottle.domain.post.dto.PostRequest;
-import com.codingbottle.domain.post.dto.PostResponse;
+import com.codingbottle.domain.post.model.PostRequest;
+import com.codingbottle.domain.post.model.PostResponse;
 import com.codingbottle.domain.post.service.PostService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/module-api/src/main/java/com/codingbottle/domain/post/model/PostRequest.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/model/PostRequest.java
@@ -1,4 +1,4 @@
-package com.codingbottle.domain.post.dto;
+package com.codingbottle.domain.post.model;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/module-api/src/main/java/com/codingbottle/domain/post/model/PostResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/model/PostResponse.java
@@ -1,4 +1,4 @@
-package com.codingbottle.domain.post.dto;
+package com.codingbottle.domain.post.model;
 
 import com.codingbottle.domain.image.entity.Image;
 import com.codingbottle.domain.post.entity.Post;

--- a/module-api/src/main/java/com/codingbottle/domain/post/service/PostService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/service/PostService.java
@@ -7,7 +7,7 @@ import com.codingbottle.domain.image.entity.Image;
 import com.codingbottle.domain.image.service.ImageService;
 import com.codingbottle.domain.post.entity.Post;
 import com.codingbottle.domain.post.repo.PostRepository;
-import com.codingbottle.domain.post.dto.PostRequest;
+import com.codingbottle.domain.post.model.PostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/controller/QuizController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/controller/QuizController.java
@@ -1,0 +1,31 @@
+package com.codingbottle.domain.quiz.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.model.Type;
+import com.codingbottle.domain.quiz.service.QuizService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "퀴즈", description = "퀴즈 API")
+@RestController
+@RequestMapping("/api/quizzes")
+@RequiredArgsConstructor
+public class QuizController {
+    private final QuizService quizService;
+
+    @GetMapping
+    public ResponseEntity<List<Quiz>> getQuizzes(@AuthenticationPrincipal User user,
+                                                 @RequestParam(value = "type") Type type) {
+        List<Quiz> quizzes = quizService.findByType(user, type);
+        return ResponseEntity.ok(quizzes);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/controller/UserQuizController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/controller/UserQuizController.java
@@ -1,0 +1,29 @@
+package com.codingbottle.domain.quiz.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.service.UserQuizService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "오답 퀴즈", description = "오답 퀴즈 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserQuizController {
+    private final UserQuizService userQuizService;
+
+    @GetMapping("/wrong-quizzes")
+    public ResponseEntity<List<Quiz>> getWrongQuizzes(@AuthenticationPrincipal User user) {
+        List<Quiz> wrongQuizzes = userQuizService.findRandomWrongQuizzesByUser(user);
+
+        return ResponseEntity.ok(wrongQuizzes);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
@@ -1,0 +1,24 @@
+package com.codingbottle.domain.quiz.model;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
+
+import java.util.List;
+
+public enum Type {
+    TODAY{
+        @Override
+        public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
+            return quizRepository.findRandomQuizzes(user, 3);
+        }
+    },
+    NORMAL{
+        @Override
+        public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
+            return quizRepository.findRandomQuizzes(user, 10);
+        }
+    };
+
+    public abstract List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository);
+}

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/service/QuizService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/service/QuizService.java
@@ -1,0 +1,22 @@
+package com.codingbottle.domain.quiz.service;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.model.Type;
+import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QuizService {
+    private final QuizQueryRepository quizRepository;
+
+    public List<Quiz> findByType(User user, Type type) {
+        return type.getQuizzes(user, quizRepository);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
@@ -1,0 +1,28 @@
+package com.codingbottle.domain.quiz.service;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.exception.ApplicationErrorException;
+import com.codingbottle.common.exception.ApplicationErrorType;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserQuizService {
+    private final UserQuizQueryRepository userQuizQueryRepository;
+
+    public List<Quiz> findRandomWrongQuizzesByUser(User user) {
+        List<Quiz> randomWrongQuizzes = userQuizQueryRepository.findRandomWrongQuizzesByUser(user);
+
+        if (randomWrongQuizzes.isEmpty()) {
+            throw new ApplicationErrorException(ApplicationErrorType.NOT_EXIT_WRONG_ANSWER);
+        }
+        return randomWrongQuizzes;
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
@@ -2,7 +2,7 @@ package com.codingbottle.domain.post.controller;
 
 import com.codingbottle.auth.entity.User;
 import com.codingbottle.docs.util.RestDocsTest;
-import com.codingbottle.domain.post.dto.PostRequest;
+import com.codingbottle.domain.post.model.PostRequest;
 import com.codingbottle.domain.post.service.PostService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,6 +72,8 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("content[].image.id").description("게시물 이미지 id"),
                                 fieldWithPath("content[].image.imageUrl").description("게시물 이미지 url"),
                                 fieldWithPath("content[].image.directory").description("게시물 이미지 디렉토리"),
+                                fieldWithPath("content[].image.createdTime").description("게시물 이미지 생성시간").type("LocalDateTime"),
+                                fieldWithPath("content[].image.modifiedTime").description("게시물 이미지 수정시간").type("LocalDateTime"),
                                 fieldWithPath("content[].image.convertImageName").description("게시물 이미지 convertImageName"),
                                 fieldWithPath("content[].createdTime").description("게시물 생성시간").type("LocalDateTime"),
                                 fieldWithPath("content[].modifiedTime").description("게시물 수정시간").type("LocalDateTime"),
@@ -183,6 +185,8 @@ class PostControllerTest extends RestDocsTest {
                 fieldWithPath("image.id").description("게시물 이미지 id").type("Number"),
                 fieldWithPath("image.imageUrl").description("게시물 이미지 url"),
                 fieldWithPath("image.directory").description("게시물 이미지 디렉토리"),
+                fieldWithPath("image.createdTime").description("게시물 이미지 생성시간").type("LocalDateTime"),
+                fieldWithPath("image.modifiedTime").description("게시물 이미지 수정시간").type("LocalDateTime"),
                 fieldWithPath("image.convertImageName").description("게시물 이미지 convertImageName"),
                 fieldWithPath("createdTime").description("게시물 생성시간").type("LocalDateTime"),
                 fieldWithPath("modifiedTime").description("게시물 수정시간").type("LocalDateTime")

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/QuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/QuizControllerTest.java
@@ -1,0 +1,70 @@
+package com.codingbottle.domain.quiz.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.docs.util.RestDocsTest;
+import com.codingbottle.domain.quiz.model.Type;
+import com.codingbottle.domain.quiz.service.QuizService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.*;
+import static com.codingbottle.fixture.DomainFixture.퀴즈1;
+import static com.codingbottle.fixture.DomainFixture.퀴즈2;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("QuizController 테스트")
+@ContextConfiguration(classes = QuizController.class)
+@WebMvcTest(value = QuizController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class QuizControllerTest extends RestDocsTest {
+    @MockBean
+    private QuizService quizService;
+
+    private static final String REQUEST_URL = "/api/quizzes";
+
+    @Test
+    @DisplayName("오늘의 퀴즈를 조회한다")
+    void get_today_quiz() throws Exception {
+        //given
+        given(quizService.findByType(any(User.class), any(Type.class))).willReturn(List.of(퀴즈1, 퀴즈2));
+        //when & then
+        mvc.perform(get(REQUEST_URL)
+                        .queryParam("type", "TODAY")
+                        .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("quiz-list",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        queryParameters(
+                                parameterWithName("type").description("오늘의 퀴즈 (TODAY) / 퀴즈 풀어보기 (NORMAL)")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].id").description("퀴즈 ID").type("Number"),
+                                fieldWithPath("[].question").description("퀴즈 제목"),
+                                fieldWithPath("[].answer").description("퀴즈 정답"),
+                                fieldWithPath("[].quizType").description("퀴즈 타입 (MultipleChoice / OX)"),
+                                fieldWithPath("[].choices.*").description("퀴즈 보기 (객관식은 4개, OX는 2개)").type("Map"),
+                                fieldWithPath("[].image").description("퀴즈 이미지 (null일 수 있음)").optional(),
+                                fieldWithPath("[].image.id").description("퀴즈 이미지 id").type("Number"),
+                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url"),
+                                fieldWithPath("[].image.directory").description("퀴즈 이미지 디렉토리"),
+                                fieldWithPath("[].image.createdTime").description("퀴즈 이미지 생성시간").type("LocalDateTime"),
+                                fieldWithPath("[].image.modifiedTime").description("퀴즈 이미지 수정시간").type("LocalDateTime"),
+                                fieldWithPath("[].image.convertImageName").description("퀴즈 이미지 변환 이미지 이름")
+                )));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
@@ -1,0 +1,63 @@
+package com.codingbottle.domain.quiz.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.docs.util.RestDocsTest;
+import com.codingbottle.domain.quiz.service.UserQuizService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.*;
+import static com.codingbottle.fixture.DomainFixture.퀴즈1;
+import static com.codingbottle.fixture.DomainFixture.퀴즈2;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("UserQuizController 테스트")
+@ContextConfiguration(classes = UserQuizController.class)
+@WebMvcTest(value = UserQuizController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class UserQuizControllerTest extends RestDocsTest {
+    @MockBean
+    private UserQuizService userQuizService;
+
+    private static final String REQUEST_URL = "/api/users";
+
+    @Test
+    @DisplayName("사용자 오답 퀴즈를 조회한다")
+    void get_wrong_quizzes() throws Exception {
+        //given
+        given(userQuizService.findRandomWrongQuizzesByUser(any(User.class))).willReturn(List.of(퀴즈1, 퀴즈2));
+        //when & then
+        mvc.perform(get(REQUEST_URL + "/wrong-quizzes")
+                .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("wrong-answer-list",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        responseFields(
+                                fieldWithPath("[].id").description("퀴즈 ID").type("Number"),
+                                fieldWithPath("[].question").description("퀴즈 제목"),
+                                fieldWithPath("[].answer").description("퀴즈 정답"),
+                                fieldWithPath("[].quizType").description("퀴즈 타입 (MultipleChoice / OX)"),
+                                fieldWithPath("[].choices.*").description("퀴즈 보기 (객관식은 4개, OX는 2개)").type("Map"),
+                                fieldWithPath("[].image").description("퀴즈 이미지 (null일 수 있음)").optional(),
+                                fieldWithPath("[].image.id").description("퀴즈 이미지 id").type("Number"),
+                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url"),
+                                fieldWithPath("[].image.directory").description("퀴즈 이미지 디렉토리"),
+                                fieldWithPath("[].image.createdTime").description("퀴즈 이미지 생성시간").type("LocalDateTime"),
+                                fieldWithPath("[].image.modifiedTime").description("퀴즈 이미지 수정시간").type("LocalDateTime"),
+                                fieldWithPath("[].image.convertImageName").description("퀴즈 이미지 변환 이미지 이름")
+                        )));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
@@ -1,0 +1,44 @@
+package com.codingbottle.domain.quiz.service;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.model.Type;
+import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.codingbottle.fixture.DomainFixture.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class QuizServiceTest {
+    @InjectMocks
+    private QuizService quizService;
+
+    @Mock
+    private QuizQueryRepository quizRepository;
+
+    @ParameterizedTest
+    @CsvSource({"TODAY","NORMAL"})
+    @DisplayName("퀴즈 타입으로 퀴즈를 조회한다")
+    void findByType(Type type) {
+        //given
+        given(quizRepository.findRandomQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
+        //when
+        List<Quiz> quizzes = quizService.findByType(유저1, type);
+        //then
+        assertThat(quizzes.size()).isEqualTo(2);
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/UserQuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/UserQuizServiceTest.java
@@ -1,0 +1,49 @@
+package com.codingbottle.domain.quiz.service;
+
+import com.codingbottle.common.exception.ApplicationErrorException;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.codingbottle.fixture.DomainFixture.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserQuizServiceTest {
+    @InjectMocks
+    private UserQuizService userQuizService;
+
+    @Mock
+    private UserQuizQueryRepository userQuizQueryRepository;
+
+    @Test
+    @DisplayName("틀린 문제가 없으면 예외를 던진다")
+    void if_there_is_no_wrong_answer_then_throw_exception() {
+        //given
+        given(userQuizQueryRepository.findRandomWrongQuizzesByUser(any())).willReturn(List.of());
+        //when & then
+        assertThatThrownBy(() -> userQuizService.findRandomWrongQuizzesByUser(유저1))
+                .isInstanceOf(ApplicationErrorException.class);
+    }
+
+    @Test
+    @DisplayName("틀린 문제 중 랜덤으로 문제를 조회한다")
+    void find_random_wrong_quizzes() {
+        //given
+        given(userQuizQueryRepository.findRandomWrongQuizzesByUser(any())).willReturn(List.of(퀴즈1, 퀴즈2));
+        //when
+        List<Quiz> quizzes = userQuizService.findRandomWrongQuizzesByUser(유저1);
+        //then
+        assertThat(quizzes).isEqualTo(List.of(퀴즈1, 퀴즈2));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -10,6 +10,8 @@ import com.codingbottle.domain.quiz.entity.Quiz;
 import com.codingbottle.domain.quiz.entity.QuizType;
 import com.codingbottle.domain.region.entity.Region;
 
+import java.util.HashMap;
+
 
 public class DomainFixture {
     public static final Image 게시글1_이미지 = Image.builder()
@@ -60,6 +62,42 @@ public class DomainFixture {
             .directory(Directory.POST)
             .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
             .convertImageName("default.png")
+            .build();
+
+    public static final Image 퀴즈_이미지1 = Image.builder()
+            .directory(Directory.QUIZ)
+            .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
+            .convertImageName("default.png")
+            .build();
+
+    public static final Quiz 퀴즈1 = Quiz.builder()
+            .answer("답")
+            .question("질문")
+            .choices(new HashMap<>(){
+                {
+                    put("1", "선택지1");
+                    put("2", "선택지2");
+                    put("3", "선택지3");
+                    put("4", "선택지4");
+                }
+            })
+            .quizType(QuizType.MULTIPLE_CHOICE)
+            .image(null)
+            .build();
+
+    public static final Quiz 퀴즈2 = Quiz.builder()
+            .answer("답")
+            .question("질문")
+            .choices(new HashMap<>(){
+                {
+                    put("1", "선택지1");
+                    put("2", "선택지2");
+                    put("3", "선택지3");
+                    put("4", "선택지4");
+                }
+            })
+            .quizType(QuizType.OX)
+            .image(퀴즈_이미지1)
             .build();
 }
 

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -5,7 +5,9 @@ import com.codingbottle.auth.entity.User;
 import com.codingbottle.domain.image.entity.Directory;
 import com.codingbottle.domain.image.entity.Image;
 import com.codingbottle.domain.post.entity.Post;
-import com.codingbottle.domain.post.dto.PostRequest;
+import com.codingbottle.domain.post.model.PostRequest;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.entity.QuizType;
 import com.codingbottle.domain.region.entity.Region;
 
 

--- a/module-core/build.gradle
+++ b/module-core/build.gradle
@@ -7,6 +7,10 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/module-core/build.gradle
+++ b/module-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'com.h2database:h2'
 }
 
 test {

--- a/module-core/src/main/java/com/codingbottle/auth/entity/User.java
+++ b/module-core/src/main/java/com/codingbottle/auth/entity/User.java
@@ -14,9 +14,8 @@ import java.util.Collections;
 
 @Getter
 @Entity
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,9 +25,6 @@ public class User implements UserDetails {
     @Column(name = "username", nullable = false, unique = true)
     private String username;
 
-    @Column(name = "role", nullable = false)
-    private Role role;
-
     @Column(name = "email", nullable = false)
     private String email;
 
@@ -37,6 +33,10 @@ public class User implements UserDetails {
 
     @Column(name = "picture")
     private String picture;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private Role role;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "region", nullable = false)
@@ -88,6 +88,16 @@ public class User implements UserDetails {
         this.region = region;
 
         return this;
+    }
+
+    @Builder
+    public User(String username, String email, String name, String picture, Role role, Region region) {
+        this.username = username;
+        this.email = email;
+        this.name = name;
+        this.picture = picture;
+        this.role = role;
+        this.region = region;
     }
 
     @Override

--- a/module-core/src/main/java/com/codingbottle/common/config/QueryDslConfig.java
+++ b/module-core/src/main/java/com/codingbottle/common/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.codingbottle.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/common/entity/BaseEntity.java
+++ b/module-core/src/main/java/com/codingbottle/common/entity/BaseEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class ObjectTime {
+public abstract class BaseEntity {
     @CreatedDate
     private LocalDateTime createdTime;
 

--- a/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
@@ -11,6 +11,7 @@ public enum ApplicationErrorType {
     INVALID_HEADER(HttpStatus.BAD_REQUEST, "Header 값이 올바르지 않습니다."),
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST, "Firebase 토큰이 올바르지 않습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "파일 타입이 올바르지 않습니다."),
+    NOT_EXIT_WRONG_ANSWER(HttpStatus.BAD_REQUEST, "틀린 문제가 없습니다."),
     //401
     NO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     //404

--- a/module-core/src/main/java/com/codingbottle/domain/image/entity/Image.java
+++ b/module-core/src/main/java/com/codingbottle/domain/image/entity/Image.java
@@ -1,5 +1,6 @@
 package com.codingbottle.domain.image.entity;
 
+import com.codingbottle.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +10,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Image {
+public class Image extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)

--- a/module-core/src/main/java/com/codingbottle/domain/post/entity/Post.java
+++ b/module-core/src/main/java/com/codingbottle/domain/post/entity/Post.java
@@ -1,8 +1,8 @@
 package com.codingbottle.domain.post.entity;
 
 import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.entity.BaseEntity;
 import com.codingbottle.domain.image.entity.Image;
-import com.codingbottle.common.entity.ObjectTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,14 +12,14 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post extends ObjectTime {
+public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_num")
     private Long id;
 
-    @Column(name = "post_content")
     @Lob
+    @Column(name = "post_content")
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/entity/Quiz.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/entity/Quiz.java
@@ -1,0 +1,67 @@
+package com.codingbottle.domain.quiz.entity;
+
+import com.codingbottle.domain.image.entity.Image;
+import com.google.common.base.Objects;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Quiz {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "quiz_question", columnDefinition = "TEXT", nullable = false)
+    private String question;
+
+    @Column(name = "quiz_answer", columnDefinition = "TEXT", nullable = false)
+    private String answer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "quiz_type", nullable = false)
+    private QuizType quizType;
+
+    @ElementCollection
+    @CollectionTable(name = "quiz_choices", joinColumns = @JoinColumn(name = "quiz_id"))
+    @MapKeyColumn(name = "choice_number")
+    @Column(name = "choice", columnDefinition = "TEXT", nullable = false)
+    private Map<String, String> choices;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @Builder
+    public Quiz(String question, String answer, QuizType quizType, Map<String, String> choices, Image image) {
+        this.question = question;
+        this.answer = answer;
+        this.quizType = quizType;
+        this.choices = choices;
+        this.image = image;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Quiz quiz = (Quiz) o;
+        return Objects.equal(id, quiz.id)
+                && Objects.equal(question, quiz.question)
+                && Objects.equal(answer, quiz.answer)
+                && quizType == quiz.quizType
+                && Objects.equal(choices, quiz.choices)
+                && Objects.equal(image, quiz.image);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, question, answer, quizType, choices, image);
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/entity/QuizStatus.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/entity/QuizStatus.java
@@ -1,0 +1,6 @@
+package com.codingbottle.domain.quiz.entity;
+
+public enum QuizStatus {
+    WRONG,
+    CORRECT
+}

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/entity/QuizType.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/entity/QuizType.java
@@ -1,0 +1,6 @@
+package com.codingbottle.domain.quiz.entity;
+
+public enum QuizType {
+    MULTIPLE_CHOICE,
+    OX
+}

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/entity/UserQuiz.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/entity/UserQuiz.java
@@ -1,0 +1,36 @@
+package com.codingbottle.domain.quiz.entity;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserQuiz extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuizStatus quizStatus;
+
+    @Builder
+    public UserQuiz(Quiz quiz, User user, QuizStatus quizStatus) {
+        this.quiz = quiz;
+        this.user = user;
+        this.quizStatus = quizStatus;
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/repo/QuizQueryRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/repo/QuizQueryRepository.java
@@ -1,0 +1,31 @@
+package com.codingbottle.domain.quiz.repo;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.QQuiz;
+import com.codingbottle.domain.quiz.entity.QUserQuiz;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.entity.QuizStatus;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class QuizQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QQuiz qQuiz = QQuiz.quiz;
+    private final QUserQuiz qUserQuiz = QUserQuiz.userQuiz;
+
+    public List<Quiz> findRandomQuizzes(User user, int limit) {
+        return jpaQueryFactory.selectFrom(qQuiz)
+                .leftJoin(qUserQuiz)
+                .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user), qUserQuiz.quizStatus.eq(QuizStatus.CORRECT))
+                .where(qUserQuiz.id.isNull())
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/repo/QuizSimpleJPARepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/repo/QuizSimpleJPARepository.java
@@ -1,0 +1,7 @@
+package com.codingbottle.domain.quiz.repo;
+
+import com.codingbottle.domain.quiz.entity.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizSimpleJPARepository extends JpaRepository<Quiz, Long> {
+}

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/repo/UserQuizQueryRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/repo/UserQuizQueryRepository.java
@@ -1,0 +1,29 @@
+package com.codingbottle.domain.quiz.repo;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.QUserQuiz;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.entity.QuizStatus;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQuizQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QUserQuiz qUserQuiz = QUserQuiz.userQuiz;
+    public List<Quiz> findRandomWrongQuizzesByUser(User user) {
+        return jpaQueryFactory.select(qUserQuiz.quiz)
+                .from(qUserQuiz)
+                .where(qUserQuiz.user.eq(user)
+                        .and(qUserQuiz.quizStatus.eq(QuizStatus.WRONG)))
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(5)
+                .fetch();
+    }
+}
+

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/repo/UserQuizSimpleJPARepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/repo/UserQuizSimpleJPARepository.java
@@ -1,0 +1,7 @@
+package com.codingbottle.domain.quiz.repo;
+
+import com.codingbottle.domain.quiz.entity.UserQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserQuizSimpleJPARepository extends JpaRepository<UserQuiz, Long> {
+}

--- a/module-core/src/test/java/com/codingbottle/CoreApplicationTest.java
+++ b/module-core/src/test/java/com/codingbottle/CoreApplicationTest.java
@@ -1,0 +1,7 @@
+package com.codingbottle;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CoreApplicationTest {
+}

--- a/module-core/src/test/java/com/codingbottle/common/annotation/RepositoryTest.java
+++ b/module-core/src/test/java/com/codingbottle/common/annotation/RepositoryTest.java
@@ -1,0 +1,19 @@
+package com.codingbottle.common.annotation;
+
+import com.codingbottle.common.config.TestQueryDslConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestQueryDslConfig.class)
+@DataJpaTest
+public @interface RepositoryTest {
+}

--- a/module-core/src/test/java/com/codingbottle/common/config/TestQueryDslConfig.java
+++ b/module-core/src/test/java/com/codingbottle/common/config/TestQueryDslConfig.java
@@ -1,0 +1,32 @@
+package com.codingbottle.common.config;
+
+import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
+import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestQueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public QuizQueryRepository quizRepository() {
+        return new QuizQueryRepository(jpaQueryFactory());
+    }
+
+    @Bean
+    public UserQuizQueryRepository userQuizRepository() {
+        return new UserQuizQueryRepository(jpaQueryFactory());
+    }
+}

--- a/module-core/src/test/java/com/codingbottle/domain/quiz/repo/QuizQueryRepositoryTest.java
+++ b/module-core/src/test/java/com/codingbottle/domain/quiz/repo/QuizQueryRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.codingbottle.domain.quiz.repo;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.auth.repository.UserRepository;
+import com.codingbottle.common.annotation.RepositoryTest;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.codingbottle.fixture.CoreDomainFixture.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@RepositoryTest
+class QuizQueryRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private QuizSimpleJPARepository quizSimpleJPARepository;
+
+    @Autowired
+    private UserQuizSimpleJPARepository userQuizSimpleJPARepository;
+
+    @Autowired
+    private QuizQueryRepository quizQueryRepository;
+
+
+    User 유저;
+
+    @BeforeEach
+    void setUp() {
+        유저 = userRepository.save(유저1);
+        quizSimpleJPARepository.saveAll(List.of(퀴즈1, 퀴즈2));
+    }
+
+    @Test
+    @DisplayName("랜덤으로 퀴즈를 조회한다")
+    void find_random_quizzes() {
+        //when
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, 3);
+        //then
+        assertThat(randomQuizzes).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("랜덤으로 퀴즈를 조회하는데 이미 사용자가 푼 문제는 제외한다.")
+    void find_random_quizzes_exclude_user_quiz() {
+        //given
+        userQuizSimpleJPARepository.save(유저1_퀴즈1);
+        //when
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, 3);
+        //then
+        assertThat(randomQuizzes).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1, 1", "2, 2"})
+    @DisplayName("랜덤으로 퀴즈를 조회하는데 limit을 지정할 수 있다.")
+    void find_random_quizzes_limit(int limit, int expectedSize) {
+        //when
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, limit);
+        //then
+        assertThat(randomQuizzes).hasSize(expectedSize);
+    }
+}

--- a/module-core/src/test/java/com/codingbottle/domain/quiz/repo/UserQuizQueryRepositoryTest.java
+++ b/module-core/src/test/java/com/codingbottle/domain/quiz/repo/UserQuizQueryRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.codingbottle.domain.quiz.repo;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.auth.repository.UserRepository;
+import com.codingbottle.common.annotation.RepositoryTest;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.codingbottle.fixture.CoreDomainFixture.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RepositoryTest
+class UserQuizQueryRepositoryTest {
+    @Autowired
+    private UserQuizQueryRepository userQuizQueryRepository;
+
+    @Autowired
+    private UserQuizSimpleJPARepository userQuizSimpleJPARepository;
+
+    @Autowired
+    private QuizSimpleJPARepository quizSimpleJPARepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User 유저;
+
+    @BeforeEach
+    void setUp() {
+        유저 = userRepository.save(유저1);
+        quizSimpleJPARepository.saveAll(List.of(퀴즈1, 퀴즈2));
+        userQuizSimpleJPARepository.saveAll(List.of(유저1_오답1, 유저1_오답2));
+    }
+
+    @Test
+    @DisplayName("유저가 틀린 문제를 조회한다.")
+    void find_user_wrong_quizzes() {
+        //when
+        List<Quiz> randomWrongQuizzesByUser = userQuizQueryRepository.findRandomWrongQuizzesByUser(유저);
+        //then
+        assertThat(randomWrongQuizzesByUser).isEqualTo(List.of(퀴즈1, 퀴즈2));
+    }
+}

--- a/module-core/src/test/java/com/codingbottle/fixture/CoreDomainFixture.java
+++ b/module-core/src/test/java/com/codingbottle/fixture/CoreDomainFixture.java
@@ -1,0 +1,70 @@
+package com.codingbottle.fixture;
+
+import com.codingbottle.auth.entity.Role;
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.entity.QuizStatus;
+import com.codingbottle.domain.quiz.entity.QuizType;
+import com.codingbottle.domain.quiz.entity.UserQuiz;
+import com.codingbottle.domain.region.entity.Region;
+
+import java.util.HashMap;
+
+public class CoreDomainFixture {
+    public static final User 유저1 = User.builder()
+            .username("유저1")
+            .email("helfy@gmail.com")
+            .region(Region.SEOUL)
+            .picture("https://d1csu9i9ktup9e.cloudfront.net/default.png")
+            .role(Role.ROLE_USER)
+            .name("이름")
+            .build();
+
+    public static final Quiz 퀴즈1 = Quiz.builder()
+            .answer("답")
+            .question("질문")
+            .choices(new HashMap<>(){
+                {
+                    put("1", "선택지1");
+                    put("2", "선택지2");
+                    put("3", "선택지3");
+                    put("4", "선택지4");
+                }
+            })
+            .quizType(QuizType.MULTIPLE_CHOICE)
+            .image(null)
+            .build();
+
+    public static final Quiz 퀴즈2 = Quiz.builder()
+            .answer("답")
+            .question("질문")
+            .choices(new HashMap<>(){
+                {
+                    put("1", "선택지1");
+                    put("2", "선택지2");
+                    put("3", "선택지3");
+                    put("4", "선택지4");
+                }
+            })
+            .quizType(QuizType.MULTIPLE_CHOICE)
+            .image(null)
+            .build();
+
+    public static final UserQuiz 유저1_퀴즈1 = UserQuiz.builder()
+            .user(유저1)
+            .quiz(퀴즈1)
+            .quizStatus(QuizStatus.CORRECT)
+            .build();
+
+    public static final UserQuiz 유저1_오답1 = UserQuiz.builder()
+            .user(유저1)
+            .quiz(퀴즈1)
+            .quizStatus(QuizStatus.WRONG)
+            .build();
+
+    public static final UserQuiz 유저1_오답2 = UserQuiz.builder()
+            .user(유저1)
+            .quiz(퀴즈2)
+            .quizStatus(QuizStatus.WRONG)
+            .build();
+}

--- a/module-core/src/test/resources/application.yml
+++ b/module-core/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    username: sa
+    password: password
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL57Dialect
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: create-drop
+    generate-ddl: true


### PR DESCRIPTION
## :sparkles: 이슈 번호: #26 


## :bulb: 상세 내용:
- 랜덤하게 퀴즈를 조회하는 API 구성 (오늘의 퀴즈, 퀴즈 풀어보기, 오답 퀴즈 풀어보기)
- queryDsl을 이용하여 랜덤하게 퀴즈를 조회하는 동적 쿼리 작성
- 사용자가 푼 퀴즈는 조회되지 않도록 쿼리 구성
- queryDsl 테스트 코드 작성, h2 데이터 베이스 사용
- 퀴즈 정답, 퀴즈 오답 API에 대한 로직은 제외

