### PR TITLE
OpenWeatherMap API 요청시 발생하는 예외 처리

### DIFF
--- a/module-api/src/main/java/com/codingbottle/common/config/WebClientConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/config/WebClientConfig.java
@@ -24,10 +24,10 @@ public class WebClientConfig {
     public WebClient webClient() {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
-                .responseTimeout(Duration.ofMillis(10000))
+                .responseTimeout(Duration.ofSeconds(15))
                 .doOnConnected(conn -> conn
-                        .addHandlerLast(new ReadTimeoutHandler(10000, TimeUnit.MILLISECONDS))
-                        .addHandlerLast(new WriteTimeoutHandler(10000, TimeUnit.MILLISECONDS)));
+                        .addHandlerLast(new ReadTimeoutHandler(15, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(15, TimeUnit.SECONDS)));
 
         return WebClient.builder()
                 .baseUrl(openWeatherMapUrl)

--- a/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @AllArgsConstructor
 public enum ApplicationErrorType {
     //400
@@ -19,13 +20,13 @@ public enum ApplicationErrorType {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
     //500
+    WEATHER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "날씨 정보를 가져오는데 실패했습니다."),
+    WEB_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "WebClient 에러가 발생했습니다."),
     FAIL_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패하였습니다"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시만 기달려주세요.");
 
-    @Getter
     private final HttpStatus httpStatus;
 
-    @Getter
     private final String message;
 
     public int getStatusCode() {


### PR DESCRIPTION
## :sparkles: 이슈 번호: #37 


## :bulb: 상세 내용:
- webClient 요청 실패시 3번 더 시도하도록 변경
- 서버 읽기와 쓰기 시간을 더 늘려 읽기 시간 초과 발생 가능성을 줄임
- 날씨 정보 예외 코드 추가
