### PR TITLE
사용자 퀴즈 정보 API 구현 및 쿼리 수정

### DIFF
--- a/module-api/src/docs/asciidoc/퀴즈-API.adoc
+++ b/module-api/src/docs/asciidoc/퀴즈-API.adoc
@@ -22,3 +22,7 @@ operation::put-quiz-status[snippets='http-request,path-parameters,request-body,r
 IMPORTANT:  (만약 틀린 문제가 없으면 오류 응답)
 
 operation::wrong-answer-list[snippets='http-request,http-response,response-fields']
+
+[[사용자-퀴즈-점수-조회]]
+== 사용자 닉네임, 점수 조회
+operation::get-user-quiz-info[snippets='http-request,http-response,response-fields']

--- a/module-api/src/main/java/com/codingbottle/common/redis/service/QuizRankRedisService.java
+++ b/module-api/src/main/java/com/codingbottle/common/redis/service/QuizRankRedisService.java
@@ -29,12 +29,12 @@ public class QuizRankRedisService {
         return Optional.ofNullable(zSetOperations.score(QUIZ_RANK_KEY, user));
     }
 
-    public void addScore(String user, double score) {
+    public void addScore(String user, int score) {
         zSetOperations.add(QUIZ_RANK_KEY, user, score);
     }
 
-    public void updateScore(String user, double score) {
-        double newScore = getScore(user).orElse(0.0) + score;
+    public void updateScore(String user, int score) {
+        int newScore = (int) (getScore(user).orElse(0.0) + score);
         addScore(user, newScore);
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/image/controller/ImageController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/image/controller/ImageController.java
@@ -22,6 +22,6 @@ public class ImageController {
                                                      @RequestPart("image") MultipartFile image) {
         Image upload = imageService.upload(image, directory);
 
-        return ResponseEntity.ok(ImageResponse.of(upload));
+        return ResponseEntity.ok(ImageResponse.from(upload));
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/image/model/ImageResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/image/model/ImageResponse.java
@@ -8,7 +8,7 @@ public record ImageResponse(
          Long id,
          String imageUrl
 ) {
-    public static ImageResponse of(Image image) {
+    public static ImageResponse from(Image image) {
         return ImageResponse.builder()
                 .id(image.getId())
                 .imageUrl(image.getImageUrl())

--- a/module-api/src/main/java/com/codingbottle/domain/information/model/InformationResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/information/model/InformationResponse.java
@@ -19,7 +19,7 @@ public record InformationResponse(
                 information.getContent(),
                 information.getNews(),
                 information.getYoutube(),
-                ImageResponse.of(information.getImage())
+                ImageResponse.from(information.getImage())
         );
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/post/model/PostResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/model/PostResponse.java
@@ -16,10 +16,10 @@ public record PostResponse(
         LocalDateTime modifiedTime
 ) {
     public static PostResponse from(Post post, Boolean likeStatus) {
-        return new PostResponse(post.getId(), post.getContent(), post.getUser().getNickname(), ImageResponse.of(post.getImage()), post.getLikes().size(), likeStatus, post.getCreatedTime(), post.getModifiedTime());
+        return new PostResponse(post.getId(), post.getContent(), post.getUser().getNickname(), ImageResponse.from(post.getImage()), post.getLikes().size(), likeStatus, post.getCreatedTime(), post.getModifiedTime());
     }
 
     public static PostResponse from(Post post) {
-        return new PostResponse(post.getId(), post.getContent(), post.getUser().getNickname(), ImageResponse.of(post.getImage()), post.getLikes().size(), false, post.getCreatedTime(), post.getModifiedTime());
+        return new PostResponse(post.getId(), post.getContent(), post.getUser().getNickname(), ImageResponse.from(post.getImage()), post.getLikes().size(), false, post.getCreatedTime(), post.getModifiedTime());
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/controller/QuizController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/controller/QuizController.java
@@ -1,7 +1,7 @@
 package com.codingbottle.domain.quiz.controller;
 
 import com.codingbottle.auth.entity.User;
-import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.model.QuizResponse;
 import com.codingbottle.domain.quiz.model.QuizStatusRequest;
 import com.codingbottle.domain.quiz.model.Type;
 import com.codingbottle.domain.quiz.service.QuizService;
@@ -14,6 +14,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Tag(name = "퀴즈", description = "퀴즈 API")
 @RestController
@@ -24,9 +25,12 @@ public class QuizController {
     private final UserQuizService userQuizService;
 
     @GetMapping
-    public ResponseEntity<List<Quiz>> getQuizzes(@AuthenticationPrincipal User user,
+    public ResponseEntity<List<QuizResponse>> getQuizzes(@AuthenticationPrincipal User user,
                                                  @RequestParam(value = "type") Type type) {
-        List<Quiz> quizzes = quizService.findByType(user, type);
+        List<QuizResponse> quizzes = quizService.findByType(user, type).stream()
+                .map(QuizResponse::from)
+                .collect(Collectors.toList());
+        
         return ResponseEntity.ok(quizzes);
     }
 

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/controller/UserQuizController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/controller/UserQuizController.java
@@ -1,7 +1,8 @@
 package com.codingbottle.domain.quiz.controller;
 
 import com.codingbottle.auth.entity.User;
-import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.model.QuizResponse;
+import com.codingbottle.domain.quiz.model.UserQuizInfo;
 import com.codingbottle.domain.quiz.service.UserQuizService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -12,18 +13,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-@Tag(name = "오답 퀴즈", description = "오답 퀴즈 API")
+@Tag(name = "사용자 퀴즈 정보", description = "퀴즈 사용자 관련 API")
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1/quiz/users")
 @RequiredArgsConstructor
 public class UserQuizController {
     private final UserQuizService userQuizService;
 
-    @GetMapping("/wrong-quiz")
-    public ResponseEntity<List<Quiz>> getWrongQuizzes(@AuthenticationPrincipal User user) {
-        List<Quiz> wrongQuizzes = userQuizService.findRandomWrongQuizzesByUser(user);
+    @GetMapping("/wrong")
+    public ResponseEntity<List<QuizResponse>> getWrongQuizzes(@AuthenticationPrincipal User user) {
+        List<QuizResponse> wrongQuizzes = userQuizService.findRandomWrongQuizzesByUser(user).stream()
+                .map(QuizResponse::from)
+                .collect(Collectors.toList());
 
         return ResponseEntity.ok(wrongQuizzes);
+    }
+
+    @GetMapping
+    public ResponseEntity<UserQuizInfo> getUserQuizInfo(@AuthenticationPrincipal User user) {
+        UserQuizInfo userQuizInfo = userQuizService.getUserQuizInfo(user);
+        return ResponseEntity.ok(userQuizInfo);
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/QuizResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/QuizResponse.java
@@ -1,0 +1,19 @@
+package com.codingbottle.domain.quiz.model;
+
+import com.codingbottle.domain.image.model.ImageResponse;
+import com.codingbottle.domain.quiz.entity.Quiz;
+import com.codingbottle.domain.quiz.entity.QuizType;
+
+import java.util.Map;
+
+public record QuizResponse(
+        Long id,
+        String question,
+        String answer,
+        Map<String, String> choices,
+        ImageResponse image,
+        QuizType quizType) {
+    public static QuizResponse from(Quiz quiz) {
+        return new QuizResponse(quiz.getId(),quiz.getQuestion(), quiz.getAnswer(), quiz.getChoices(), quiz.getImage() == null ? null : ImageResponse.from(quiz.getImage()), quiz.getQuizType());
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
@@ -16,7 +16,7 @@ public enum Type {
     NORMAL{
         @Override
         public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
-            return quizRepository.findRandomQuizzes(user, 10);
+            return quizRepository.findRandomWrongQuizzes(user, 10);
         }
     };
 

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/UserQuizInfo.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/UserQuizInfo.java
@@ -1,0 +1,10 @@
+package com.codingbottle.domain.quiz.model;
+
+public record UserQuizInfo(
+        String nickname,
+        int score
+) {
+    public static UserQuizInfo from(String nickname, Double score) {
+        return new UserQuizInfo(nickname, score.intValue());
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
@@ -8,6 +8,7 @@ import com.codingbottle.domain.quiz.entity.Quiz;
 import com.codingbottle.domain.quiz.entity.QuizStatus;
 import com.codingbottle.domain.quiz.entity.UserQuiz;
 import com.codingbottle.domain.quiz.model.QuizStatusRequest;
+import com.codingbottle.domain.quiz.model.UserQuizInfo;
 import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
 import com.codingbottle.domain.quiz.repo.UserQuizSimpleJPARepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -64,7 +66,7 @@ public class UserQuizService {
     }
 
     private void updateScoreAndQuizStatus(User user, Long quizId, QuizStatusRequest quizStatusRequest) {
-        quizRankRedisService.updateScore(user.toString(), 10.0);
+        quizRankRedisService.updateScore(user.toString(), 10);
 
         if(existsUserQuiz(user, quizId)) {
             UserQuiz userQuiz = findUserQuiz(quizId, user);
@@ -78,5 +80,10 @@ public class UserQuizService {
         if(!existsUserQuiz(user, quizId)) {
             saveUserQuiz(user, quizId, quizStatusRequest);
         }
+    }
+
+    public UserQuizInfo getUserQuizInfo(User user) {
+        Optional<Double> score = quizRankRedisService.getScore(user.toString());
+        return UserQuizInfo.from(user.getNickname(), score.orElse(0.0));
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/QuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/QuizControllerTest.java
@@ -57,17 +57,13 @@ class QuizControllerTest extends RestDocsTest {
                         ),
                         responseFields(
                                 fieldWithPath("[].id").description("퀴즈 ID").type("Number"),
-                                fieldWithPath("[].question").description("퀴즈 제목"),
+                                fieldWithPath("[].question").description("퀴즈 질문"),
                                 fieldWithPath("[].answer").description("퀴즈 정답"),
                                 fieldWithPath("[].quizType").description("퀴즈 타입 (MultipleChoice / OX)"),
                                 fieldWithPath("[].choices.*").description("퀴즈 보기 (객관식은 4개, OX는 2개)").type("Map"),
                                 fieldWithPath("[].image").description("퀴즈 이미지 (null일 수 있음)").optional(),
                                 fieldWithPath("[].image.id").description("퀴즈 이미지 id").type("Number"),
-                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url"),
-                                fieldWithPath("[].image.directory").description("퀴즈 이미지 디렉토리"),
-                                fieldWithPath("[].image.createdTime").description("퀴즈 이미지 생성시간").type("LocalDateTime"),
-                                fieldWithPath("[].image.modifiedTime").description("퀴즈 이미지 수정시간").type("LocalDateTime"),
-                                fieldWithPath("[].image.convertImageName").description("퀴즈 이미지 변환 이미지 이름")
+                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url")
                 )));
     }
 

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
@@ -13,8 +13,7 @@ import org.springframework.test.context.ContextConfiguration;
 import java.util.List;
 
 import static com.codingbottle.docs.util.ApiDocumentUtils.*;
-import static com.codingbottle.fixture.DomainFixture.퀴즈1;
-import static com.codingbottle.fixture.DomainFixture.퀴즈2;
+import static com.codingbottle.fixture.DomainFixture.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -30,7 +29,7 @@ class UserQuizControllerTest extends RestDocsTest {
     @MockBean
     private UserQuizService userQuizService;
 
-    private static final String REQUEST_URL = "/api/v1/users";
+    private static final String REQUEST_URL = "/api/v1/quiz/users";
 
     @Test
     @DisplayName("사용자 오답 퀴즈를 조회한다")
@@ -38,7 +37,7 @@ class UserQuizControllerTest extends RestDocsTest {
         //given
         given(userQuizService.findRandomWrongQuizzesByUser(any(User.class))).willReturn(List.of(퀴즈1, 퀴즈2));
         //when & then
-        mvc.perform(get(REQUEST_URL + "/wrong-quiz")
+        mvc.perform(get(REQUEST_URL + "/wrong")
                 .header("Authorization", "Bearer FirebaseToken"))
                 .andExpect(status().isOk())
                 .andDo(document("wrong-answer-list",
@@ -47,17 +46,32 @@ class UserQuizControllerTest extends RestDocsTest {
                         getAuthorizationHeader(),
                         responseFields(
                                 fieldWithPath("[].id").description("퀴즈 ID").type("Number"),
-                                fieldWithPath("[].question").description("퀴즈 제목"),
+                                fieldWithPath("[].question").description("퀴즈 질문"),
                                 fieldWithPath("[].answer").description("퀴즈 정답"),
                                 fieldWithPath("[].quizType").description("퀴즈 타입 (MultipleChoice / OX)"),
                                 fieldWithPath("[].choices.*").description("퀴즈 보기 (객관식은 4개, OX는 2개)").type("Map"),
                                 fieldWithPath("[].image").description("퀴즈 이미지 (null일 수 있음)").optional(),
                                 fieldWithPath("[].image.id").description("퀴즈 이미지 id").type("Number"),
-                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url"),
-                                fieldWithPath("[].image.directory").description("퀴즈 이미지 디렉토리"),
-                                fieldWithPath("[].image.createdTime").description("퀴즈 이미지 생성시간").type("LocalDateTime"),
-                                fieldWithPath("[].image.modifiedTime").description("퀴즈 이미지 수정시간").type("LocalDateTime"),
-                                fieldWithPath("[].image.convertImageName").description("퀴즈 이미지 변환 이미지 이름")
+                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url")
+                        )));
+    }
+
+    @Test
+    @DisplayName("사용자 퀴즈 정보를 조회한다")
+    void get_user_quiz_info() throws Exception {
+        //given
+        given(userQuizService.getUserQuizInfo(any(User.class))).willReturn(퀴즈정보1);
+        //when & then
+        mvc.perform(get(REQUEST_URL)
+                        .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("get-user-quiz-info",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        responseFields(
+                                fieldWithPath("nickname").description("사용자 닉네임"),
+                                fieldWithPath("score").description("사용자 점수").type("Number")
                         )));
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
@@ -7,8 +7,6 @@ import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +15,6 @@ import java.util.List;
 
 import static com.codingbottle.fixture.DomainFixture.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
@@ -30,14 +27,24 @@ class QuizServiceTest {
     @Mock
     private QuizQueryRepository quizRepository;
 
-    @ParameterizedTest
-    @CsvSource({"TODAY","NORMAL"})
-    @DisplayName("퀴즈 타입으로 퀴즈를 조회한다")
-    void findByType(Type type) {
+    @Test
+    @DisplayName("일반 퀴즈를 조회한다")
+    void findByNormalQuiz() {
+        //given
+        given(quizRepository.findRandomWrongQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
+        //when
+        List<Quiz> quizzes = quizService.findByType(유저1, Type.NORMAL);
+        //then
+        assertThat(quizzes.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("오늘의 퀴즈를 조회한다")
+    void findByTodayQuiz(){
         //given
         given(quizRepository.findRandomQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
         //when
-        List<Quiz> quizzes = quizService.findByType(유저1, type);
+        List<Quiz> quizzes = quizService.findByType(유저1, Type.TODAY);
         //then
         assertThat(quizzes.size()).isEqualTo(2);
     }

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -13,6 +13,7 @@ import com.codingbottle.domain.quiz.entity.Quiz;
 import com.codingbottle.domain.quiz.entity.QuizStatus;
 import com.codingbottle.domain.quiz.entity.QuizType;
 import com.codingbottle.domain.quiz.model.QuizStatusRequest;
+import com.codingbottle.domain.quiz.model.UserQuizInfo;
 import com.codingbottle.domain.region.entity.Region;
 import com.codingbottle.domain.user.model.UserNicknameRequest;
 
@@ -125,5 +126,7 @@ public class DomainFixture {
     public static final InformationResponse 정보_응답1 = InformationResponse.of(정보1);
 
     public static final QuizStatusRequest 퀴즈_결과_요청 = new QuizStatusRequest(QuizStatus.CORRECT);
+
+    public static final UserQuizInfo 퀴즈정보1 = new UserQuizInfo("닉네임", 10);
 }
 

--- a/module-core/src/main/java/com/codingbottle/domain/quiz/repo/QuizQueryRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/quiz/repo/QuizQueryRepository.java
@@ -19,11 +19,23 @@ public class QuizQueryRepository {
     private final QQuiz qQuiz = QQuiz.quiz;
     private final QUserQuiz qUserQuiz = QUserQuiz.userQuiz;
 
+    public List<Quiz> findRandomWrongQuizzes(User user, int limit) {
+        return jpaQueryFactory.selectFrom(qQuiz)
+                .leftJoin(qUserQuiz)
+                .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user))
+                .where(qUserQuiz.quizStatus.eq(QuizStatus.WRONG)
+                        .or(qUserQuiz.quizStatus.isNull()))
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(limit)
+                .fetch();
+    }
+
     public List<Quiz> findRandomQuizzes(User user, int limit) {
         return jpaQueryFactory.selectFrom(qQuiz)
                 .leftJoin(qUserQuiz)
-                .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user), qUserQuiz.quizStatus.eq(QuizStatus.CORRECT))
-                .where(qUserQuiz.id.isNull())
+                .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user))
+                .where(qUserQuiz.quizStatus.ne(QuizStatus.CORRECT)
+                        .or(qUserQuiz.quizStatus.isNull()))
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .limit(limit)
                 .fetch();

--- a/module-core/src/test/java/com/codingbottle/domain/quiz/repo/QuizQueryRepositoryTest.java
+++ b/module-core/src/test/java/com/codingbottle/domain/quiz/repo/QuizQueryRepositoryTest.java
@@ -43,7 +43,7 @@ class QuizQueryRepositoryTest {
     @DisplayName("랜덤으로 퀴즈를 조회한다")
     void find_random_quizzes() {
         //when
-        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, 3);
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, 3);
         //then
         assertThat(randomQuizzes).hasSize(2);
     }
@@ -54,7 +54,7 @@ class QuizQueryRepositoryTest {
         //given
         userQuizSimpleJPARepository.save(유저1_퀴즈1);
         //when
-        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, 3);
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, 3);
         //then
         assertThat(randomQuizzes).hasSize(1);
     }
@@ -64,7 +64,7 @@ class QuizQueryRepositoryTest {
     @DisplayName("랜덤으로 퀴즈를 조회하는데 limit을 지정할 수 있다.")
     void find_random_quizzes_limit(int limit, int expectedSize) {
         //when
-        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, limit);
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, limit);
         //then
         assertThat(randomQuizzes).hasSize(expectedSize);
     }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #47 


## :bulb: 상세 내용:
- 사용자 퀴즈 정보를 제공
- 퀴즈 조회 쿼리를 수정 (오답 쿼리와 오늘의 퀴즈 쿼리를 수정)