### PR TITLE
Firebase 토큰 만료시 처리 로직 구현

### DIFF
--- a/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
@@ -15,6 +15,8 @@ public enum ApplicationErrorType {
     NOT_EXIT_WRONG_ANSWER(HttpStatus.BAD_REQUEST, "틀린 문제가 없습니다."),
     //401
     NO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    //403
+    EXPIRED_FIREBASE_TOKEN(HttpStatus.FORBIDDEN, "Firebase 토큰이 만료되었습니다."),
     //404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),


### PR DESCRIPTION
## :sparkles: 이슈 번호: #70 


## :bulb: 상세 내용:
- 토큰이 1시간 뒤 만료 되면 서버에서 해당 토큰이 만료되었다고 에러 응답을 보냄
- 잘못된 토큰이라면 잘못된 토큰 에러 응답을 보냄

