### PR TITLE
랭킹 조회 API 구현

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -82,7 +82,9 @@ jacocoTestReport {
                             "**/*Dto*",
                             "**/*Request*",
                             "**/*Response*",
-                            "**/*Exception*"
+                            "**/*Exception*",
+                            "**/*Application*",
+                            "**/*Redis*"
                     ])
                 })
         )

--- a/module-api/src/docs/asciidoc/랭킹-API.adoc
+++ b/module-api/src/docs/asciidoc/랭킹-API.adoc
@@ -1,0 +1,20 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:leveloffset: 1
+:secttlinks:
+
+[[랭킹-API]]
+= 랭킹 API
+
+[[랭킹-조회]]
+== 랭킹 조회(1~10위)
+WARNING: 밑의 예시는 유저가 3명 밖에 없어서 1~3위까지만 랭킹이 존재하지만 10위까지 랭킹이 존재한다면 10위까지 랭킹이 조회된다.
+
+operation::rank-list[snippets='http-request,http-response,response-fields']
+
+[[나의-랭킹-조회]]
+== 나의 랭킹 조회
+operation::user-rank[snippets='http-request,http-response,response-fields']

--- a/module-api/src/main/java/com/codingbottle/common/redis/service/QuizRankRedisService.java
+++ b/module-api/src/main/java/com/codingbottle/common/redis/service/QuizRankRedisService.java
@@ -1,40 +1,111 @@
 package com.codingbottle.common.redis.service;
 
-import jakarta.annotation.PostConstruct;
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.exception.ApplicationErrorException;
+import com.codingbottle.common.exception.ApplicationErrorType;
+import com.codingbottle.domain.rank.model.CacheUser;
+import com.codingbottle.domain.rank.model.UserRankResponse;
+import com.codingbottle.domain.user.model.UpdateUser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @Service
 public class QuizRankRedisService {
-    private final RedisTemplate<String, String> quizRankRedisTemplate;
-    private ZSetOperations<String, String> zSetOperations;
+    private final ZSetOperations<String, String> zSetOperations;
+    private final ObjectMapper objectMapper;
 
-    private static final String QUIZ_RANK_KEY = "quiz_rank";
+    private static final String QUIZ_RANK_KEY = "QUIZ_RANK";
+
+    @EventListener
+    public void handleUserUpdate(UpdateUser updateUser) {
+        int score = removeUserWithScore(updateUser.before());
+        addScore(updateUser.after(), score);
+    }
 
     public QuizRankRedisService(@Qualifier("quizRankRedisTemplate") RedisTemplate<String, String> quizRankRedisTemplate) {
-        this.quizRankRedisTemplate = quizRankRedisTemplate;
+        this.zSetOperations = quizRankRedisTemplate.opsForZSet();
+        this.objectMapper = new ObjectMapper();
     }
 
-    @PostConstruct
-    public void init() {
-        zSetOperations = quizRankRedisTemplate.opsForZSet();
+    public int getScore(CacheUser user) {
+        Double score = zSetOperations.score(QUIZ_RANK_KEY, convertToJson(user));
+        return getScoreAnInt(Optional.ofNullable(score));
     }
 
-    public Optional<Double> getScore(String user) {
-        return Optional.ofNullable(zSetOperations.score(QUIZ_RANK_KEY, user));
+    public void addScore(CacheUser user, int score) {
+        zSetOperations.add(QUIZ_RANK_KEY, convertToJson(user), score);
     }
 
-    public void addScore(String user, int score) {
-        zSetOperations.add(QUIZ_RANK_KEY, user, score);
+    public void updateScore(User user, int score) {
+        CacheUser cacheUser = CacheUser.from(user);
+        int newScore = getScore(cacheUser) + score;
+        addScore(cacheUser, newScore);
     }
 
-    public void updateScore(String user, int score) {
-        int newScore = (int) (getScore(user).orElse(0.0) + score);
-        addScore(user, newScore);
+    public List<UserRankResponse> getUsersRank() {
+        Set<ZSetOperations.TypedTuple<String>> rankSet = zSetOperations.reverseRangeWithScores(QUIZ_RANK_KEY, 0, 3);
+        Objects.requireNonNull(rankSet);
+
+        return rankSet.stream()
+                .map(this::convertToUserScore)
+                .collect(Collectors.toList());
+    }
+
+    private void remove(CacheUser user) {
+        zSetOperations.remove(QUIZ_RANK_KEY, convertToJson(user));
+    }
+
+    private int removeUserWithScore(CacheUser user) {
+        int score = getScore(user);
+        remove(user);
+        return score;
+    }
+
+    private static int getScoreAnInt(Optional<Double> score) {
+        return score.orElse(0.0).intValue();
+    }
+
+    private UserRankResponse convertToUserScore(ZSetOperations.TypedTuple<String> rank) {
+        CacheUser user = convertToUser(rank.getValue());
+        return UserRankResponse.of(getRank(user) + 1, user.nickname(), Objects.requireNonNull(rank.getScore()).intValue());
+    }
+
+    private CacheUser convertToUser(String userJson) {
+        try {
+            return objectMapper.readValue(userJson, CacheUser.class);
+        } catch (JsonProcessingException e) {
+            throw new ApplicationErrorException(ApplicationErrorType.JSON_PROCESSING_EXCEPTION);
+        }
+    }
+
+    private String convertToJson(CacheUser user) {
+        try {
+            return objectMapper.writeValueAsString(user);
+        } catch (JsonProcessingException e) {
+            throw new ApplicationErrorException(ApplicationErrorType.JSON_PROCESSING_EXCEPTION);
+        }
+    }
+
+    public UserRankResponse getUserRank(User user) {
+        CacheUser cacheUser = CacheUser.from(user);
+        int score = getScore(cacheUser);
+        return UserRankResponse.of(getRank(cacheUser) + 1, cacheUser.nickname(), score);
+    }
+
+    private Long getRank(CacheUser cacheUser) {
+        return zSetOperations.rank(QUIZ_RANK_KEY, convertToJson(cacheUser));
     }
 }
+

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/UserQuizInfo.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/UserQuizInfo.java
@@ -4,7 +4,7 @@ public record UserQuizInfo(
         String nickname,
         int score
 ) {
-    public static UserQuizInfo from(String nickname, Double score) {
-        return new UserQuizInfo(nickname, score.intValue());
+    public static UserQuizInfo from(String nickname, int score) {
+        return new UserQuizInfo(nickname, score);
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
@@ -11,12 +11,12 @@ import com.codingbottle.domain.quiz.model.QuizStatusRequest;
 import com.codingbottle.domain.quiz.model.UserQuizInfo;
 import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
 import com.codingbottle.domain.quiz.repo.UserQuizSimpleJPARepository;
+import com.codingbottle.domain.rank.model.CacheUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -66,7 +66,7 @@ public class UserQuizService {
     }
 
     private void updateScoreAndQuizStatus(User user, Long quizId, QuizStatusRequest quizStatusRequest) {
-        quizRankRedisService.updateScore(user.toString(), 10);
+        quizRankRedisService.updateScore(user, 10);
 
         if(existsUserQuiz(user, quizId)) {
             UserQuiz userQuiz = findUserQuiz(quizId, user);
@@ -83,7 +83,7 @@ public class UserQuizService {
     }
 
     public UserQuizInfo getUserQuizInfo(User user) {
-        Optional<Double> score = quizRankRedisService.getScore(user.toString());
-        return UserQuizInfo.from(user.getNickname(), score.orElse(0.0));
+        int score = quizRankRedisService.getScore(CacheUser.from(user));
+        return UserQuizInfo.from(user.getNickname(), score);
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/rank/controller/RankController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/rank/controller/RankController.java
@@ -1,0 +1,34 @@
+package com.codingbottle.domain.rank.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.redis.service.QuizRankRedisService;
+import com.codingbottle.domain.rank.model.UsersRankResponse;
+import com.codingbottle.domain.rank.model.UserRankResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "랭킹", description = "랭킹 API")
+@RestController
+@RequestMapping("/api/v1/rank")
+@RequiredArgsConstructor
+public class RankController {
+    private final QuizRankRedisService quizRankRedisService;
+
+    @GetMapping
+    public ResponseEntity<UsersRankResponse> getRank() {
+        List<UserRankResponse> rank = quizRankRedisService.getUsersRank();
+        return ResponseEntity.ok(UsersRankResponse.of(rank));
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<UserRankResponse> getUserRank(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(quizRankRedisService.getUserRank(user));
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/rank/model/CacheUser.java
+++ b/module-api/src/main/java/com/codingbottle/domain/rank/model/CacheUser.java
@@ -1,0 +1,16 @@
+package com.codingbottle.domain.rank.model;
+
+import com.codingbottle.auth.entity.User;
+
+public record CacheUser(
+        Long id,
+        String nickname
+) {
+    public static CacheUser from(User user) {
+        return new CacheUser(user.getId(), user.getNickname());
+    }
+
+    public static CacheUser from(Long id, String nickname) {
+        return new CacheUser(id, nickname);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/rank/model/UserRankResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/rank/model/UserRankResponse.java
@@ -1,0 +1,11 @@
+package com.codingbottle.domain.rank.model;
+
+public record UserRankResponse(
+        Long rank,
+        String nickname,
+        int score
+) {
+    public static UserRankResponse of(Long rank, String nickname, int score) {
+        return new UserRankResponse(rank, nickname, score);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/rank/model/UsersRankResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/rank/model/UsersRankResponse.java
@@ -1,0 +1,11 @@
+package com.codingbottle.domain.rank.model;
+
+import java.util.List;
+
+public record UsersRankResponse(
+        List<UserRankResponse> userRankResponses
+) {
+    public static UsersRankResponse of(List<UserRankResponse> userRankResponses) {
+        return new UsersRankResponse(userRankResponses);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/user/model/UpdateUser.java
+++ b/module-api/src/main/java/com/codingbottle/domain/user/model/UpdateUser.java
@@ -1,0 +1,12 @@
+package com.codingbottle.domain.user.model;
+
+import com.codingbottle.domain.rank.model.CacheUser;
+
+public record UpdateUser(
+        CacheUser before,
+        CacheUser after
+) {
+    public static UpdateUser of(CacheUser before, CacheUser after) {
+        return new UpdateUser(before, after);
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/domain/user/service/UserService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/user/service/UserService.java
@@ -1,14 +1,28 @@
 package com.codingbottle.domain.user.service;
 
 import com.codingbottle.auth.entity.User;
+import com.codingbottle.auth.repository.UserRepository;
+import com.codingbottle.domain.rank.model.CacheUser;
+import com.codingbottle.domain.user.model.UpdateUser;
 import com.codingbottle.domain.user.model.UserNicknameRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final UserRepository userRepository;
+
     @Transactional
     public User updateNickname(UserNicknameRequest userNicknameRequest, User user) {
-        return user.updateNickname(userNicknameRequest.nickname());
+        applicationEventPublisher.publishEvent(
+                UpdateUser.of(
+                        CacheUser.from(user),
+                        CacheUser.from(user.getId(), userNicknameRequest.nickname())));
+
+        return userRepository.save(user.updateNickname(userNicknameRequest.nickname()));
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
@@ -158,12 +158,13 @@ class PostControllerTest extends RestDocsTest {
     @DisplayName("게시글 좋아요 요청")
     void likes_put() throws Exception{
         //given
-        given(userPostLikesService.isAlreadyLikes(any(User.class), any(Long.class))).willReturn(false);
+        given(userPostLikesService.toggleLikeStatus(any(User.class), any(Long.class))).willReturn(true);
         //when & then
         mvc.perform(RestDocumentationRequestBuilders.put(REQUEST_URL + "/{id}/likes", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer FirebaseToken"))
                 .andExpect(status().isOk())
+                .andExpect(content().string("Liked"))
                 .andDo(document("put-likes",
                         getDocumentRequest(),
                         getDocumentResponse(),
@@ -182,6 +183,7 @@ class PostControllerTest extends RestDocsTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer FirebaseToken"))
                 .andExpect(status().isOk())
+                .andExpect(content().string("Unliked"))
                 .andDo(document("put-likes",
                         getDocumentRequest(),
                         getDocumentResponse(),

--- a/module-api/src/test/java/com/codingbottle/domain/rank/controller/RankControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/rank/controller/RankControllerTest.java
@@ -1,0 +1,75 @@
+package com.codingbottle.domain.rank.controller;
+
+import com.codingbottle.auth.entity.User;
+import com.codingbottle.common.redis.service.QuizRankRedisService;
+import com.codingbottle.docs.util.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+
+import static com.codingbottle.docs.util.ApiDocumentUtils.*;
+import static com.codingbottle.fixture.DomainFixture.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("RankController 테스트")
+@ContextConfiguration(classes = RankController.class)
+@WebMvcTest(value = RankController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class RankControllerTest extends RestDocsTest {
+    @MockBean
+    private QuizRankRedisService quizRankRedisService;
+
+    private static final String REQUEST_URL = "/api/v1/rank";
+
+    @Test
+    @DisplayName("1등부터 10등까지의 랭킹을 조회한다")
+    void get_rank() throws Exception {
+        //given
+        given(quizRankRedisService.getUsersRank()).willReturn(List.of(유저_랭킹1, 유저_랭킹2, 유저_랭킹3));
+        //when & then
+        mvc.perform(get(REQUEST_URL)
+                .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("rank-list",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        responseFields(
+                                fieldWithPath("userRankResponses[].rank").description("순위").type("Number"),
+                                fieldWithPath("userRankResponses[].nickname").description("닉네임"),
+                                fieldWithPath("userRankResponses[].score").description("점수").type("Number")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("유저의 랭킹을 조회한다")
+    void get_user_rank() throws Exception {
+        //given
+        given(quizRankRedisService.getUserRank(any(User.class))).willReturn(유저_랭킹1);
+        //when & then
+        mvc.perform(get(REQUEST_URL + "/user")
+                .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("user-rank",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        responseFields(
+                                fieldWithPath("rank").description("순위").type("Number"),
+                                fieldWithPath("nickname").description("닉네임"),
+                                fieldWithPath("score").description("점수").type("Number")
+                        )
+                ));
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/user/service/UserServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/user/service/UserServiceTest.java
@@ -1,27 +1,40 @@
 package com.codingbottle.domain.user.service;
 
 import com.codingbottle.auth.entity.User;
+import com.codingbottle.auth.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static com.codingbottle.fixture.DomainFixture.유저1;
 import static com.codingbottle.fixture.DomainFixture.유저_닉네임_변경_요청1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
     @InjectMocks
     private UserService userService;
 
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private UserRepository userRepository;
+
     @Test
     @DisplayName("사용자의 닉네임을 변경한다.")
     void update_nickname() {
+        //given
+        given(userRepository.save(any())).willReturn(유저1.updateNickname(유저_닉네임_변경_요청1.nickname()));
         //when
         User user = userService.updateNickname(유저_닉네임_변경_요청1, 유저1);
         //then
-        assertThat(user.getFirebaseUid()).isEqualTo(유저_닉네임_변경_요청1.nickname());
+        assertThat(user.getNickname()).isEqualTo(유저_닉네임_변경_요청1.nickname());
     }
 }

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -14,6 +14,7 @@ import com.codingbottle.domain.quiz.entity.QuizStatus;
 import com.codingbottle.domain.quiz.entity.QuizType;
 import com.codingbottle.domain.quiz.model.QuizStatusRequest;
 import com.codingbottle.domain.quiz.model.UserQuizInfo;
+import com.codingbottle.domain.rank.model.UserRankResponse;
 import com.codingbottle.domain.region.entity.Region;
 import com.codingbottle.domain.user.model.UserNicknameRequest;
 
@@ -128,5 +129,11 @@ public class DomainFixture {
     public static final QuizStatusRequest 퀴즈_결과_요청 = new QuizStatusRequest(QuizStatus.CORRECT);
 
     public static final UserQuizInfo 퀴즈정보1 = new UserQuizInfo("닉네임", 10);
+
+    public static final UserRankResponse 유저_랭킹1 = new UserRankResponse(1L, "닉네임", 30);
+
+    public static final UserRankResponse 유저_랭킹2 = new UserRankResponse(2L, "닉네임", 20);
+
+    public static final UserRankResponse 유저_랭킹3 = new UserRankResponse(3L, "닉네임", 10);
 }
 

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -35,16 +35,16 @@ public class DomainFixture {
             .build();
 
     public static final User 유저1 = User.builder()
-            .firebaseUid("firebaseUid")
-            .nickname("유저1")
+            .firebaseUid("firebaseUid1")
+            .nickname("닉네임")
             .email("helfy@gmail.com")
             .region(Region.SEOUL)
             .role(Role.ROLE_USER)
             .build();
 
     public static final User 유저2 = User.builder()
-            .firebaseUid("firebaseUid")
-            .nickname("유저2")
+            .firebaseUid("firebaseUid2")
+            .nickname("닉네임")
             .email("helfy@gmail.com")
             .region(Region.SEOUL)
             .role(Role.ROLE_USER)

--- a/module-core/src/main/java/com/codingbottle/auth/entity/User.java
+++ b/module-core/src/main/java/com/codingbottle/auth/entity/User.java
@@ -51,8 +51,7 @@ public class User implements UserDetails {
     }
 
     public User updateNickname(String nickname) {
-        this.firebaseUid = nickname;
-
+        this.nickname = nickname;
         return this;
     }
 


### PR DESCRIPTION
## :sparkles: 이슈 번호: #68 


## :bulb: 상세 내용:
- 1 ~  10등 까지 사용자 조회 (닉네임, 점수)
- 나의 랭킹 조회
- 닉네임 업데이트 시에도 redis의 저장된 유저도 수정되도록 eventListener 사용
