### PR TITLE
게시물 해시 태그 추가 및 검색 기능 구현

### DIFF
--- a/module-api/src/docs/asciidoc/게시물-API.adoc
+++ b/module-api/src/docs/asciidoc/게시물-API.adoc
@@ -28,5 +28,14 @@ operation::delete-post[snippets='http-request,path-parameters,http-response']
 
 [[게시글-좋아요-요청]]
 == 게시글 좋아요 요청
+만약 이미 좋아요를 누른 상태라면 좋아요를 취소합니다. (좋아요를 누르면 반환값으로 Liked, 취소하면 Unliked를 반환합니다.)
+
 operation::put-likes[snippets='http-request,path-parameters,http-response']
+
+[[게시글-검색]]
+== 게시글 검색
+검색어와 동일한 해시태그를 가진 게시글을 검색합니다.
+
+operation::search-keyword[snippets='http-request,query-parameters,http-response,response-fields']
+
 

--- a/module-api/src/main/java/com/codingbottle/domain/post/controller/PostController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/controller/PostController.java
@@ -17,6 +17,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "게시판", description = "게시판 API")
 @RestController
 @RequestMapping("/api/v1/posts")
@@ -37,7 +39,7 @@ public class PostController {
     public ResponseEntity<Page<PostResponse>> findAll(@PageableDefault Pageable pageable,
                                                       @AuthenticationPrincipal User user) {
         Page<PostResponse> posts = postService.findAll(pageable)
-                .map(post -> PostResponse.from(post, userPostLikesService.isAlreadyLikes(user, post.getId())));
+                .map(post -> PostResponse.of(post, userPostLikesService.isAlreadyLikes(user, post.getId())));
         return ResponseEntity.ok(posts);
     }
 
@@ -47,7 +49,7 @@ public class PostController {
                                                @AuthenticationPrincipal User user) {
         Post post = postService.update(postRequest, id, user);
         Boolean likeStatus = userPostLikesService.isAlreadyLikes(user, id);
-        return ResponseEntity.ok(PostResponse.from(post, likeStatus));
+        return ResponseEntity.ok(PostResponse.of(post, likeStatus));
     }
 
     @DeleteMapping("/{id}")
@@ -62,5 +64,13 @@ public class PostController {
                                                    @AuthenticationPrincipal User user) {
         boolean isLiked = userPostLikesService.toggleLikeStatus(user, postId);
         return ResponseEntity.ok().body(isLiked ? "Liked" : "Unliked");
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<PostResponse>> searchByKeyword(@RequestParam(value = "keyword") String keyword) {
+        List<PostResponse> posts = postService.searchByKeyword(keyword).stream()
+                .map(PostResponse::from)
+                .toList();
+        return ResponseEntity.ok(posts);
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/post/model/PostRequest.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/model/PostRequest.java
@@ -2,11 +2,18 @@ package com.codingbottle.domain.post.model;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 public record PostRequest(
         @NotBlank
         String content,
         @NotNull
-        Long imageId
+        Long imageId,
+        @Size(max = 10)
+        @Nullable
+        List<String> hashtags
 ){
 }

--- a/module-api/src/main/java/com/codingbottle/domain/post/model/PostResponse.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/model/PostResponse.java
@@ -4,10 +4,12 @@ import com.codingbottle.domain.image.model.ImageResponse;
 import com.codingbottle.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record PostResponse(
         Long id,
         String content,
+        List<String> hashtags,
         String writerNickname,
         ImageResponse image,
         int likeCount,
@@ -15,11 +17,11 @@ public record PostResponse(
         LocalDateTime createdTime,
         LocalDateTime modifiedTime
 ) {
-    public static PostResponse from(Post post, Boolean likeStatus) {
-        return new PostResponse(post.getId(), post.getContent(), post.getUser().getNickname(), ImageResponse.from(post.getImage()), post.getLikes().size(), likeStatus, post.getCreatedTime(), post.getModifiedTime());
+    public static PostResponse of(Post post, Boolean likeStatus) {
+        return new PostResponse(post.getId(), post.getContent(), post.getHashtags(), post.getUser().getNickname(), ImageResponse.from(post.getImage()), post.getLikes().size(), likeStatus, post.getCreatedTime(), post.getModifiedTime());
     }
 
     public static PostResponse from(Post post) {
-        return new PostResponse(post.getId(), post.getContent(), post.getUser().getNickname(), ImageResponse.from(post.getImage()), post.getLikes().size(), false, post.getCreatedTime(), post.getModifiedTime());
+        return new PostResponse(post.getId(), post.getContent(), post.getHashtags(), post.getUser().getNickname(), ImageResponse.from(post.getImage()), post.getLikes().size(), false, post.getCreatedTime(), post.getModifiedTime());
     }
 }

--- a/module-api/src/main/java/com/codingbottle/domain/post/service/PostService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/service/PostService.java
@@ -7,7 +7,8 @@ import com.codingbottle.common.redis.service.LikesRedisService;
 import com.codingbottle.domain.image.entity.Image;
 import com.codingbottle.domain.image.service.ImageService;
 import com.codingbottle.domain.post.entity.Post;
-import com.codingbottle.domain.post.repo.PostRepository;
+import com.codingbottle.domain.post.repo.PostQueryRepository;
+import com.codingbottle.domain.post.repo.PostSimpleJPARepository;
 import com.codingbottle.domain.post.model.PostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,13 +16,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PostService {
-    private final PostRepository postRepository;
+    private final PostSimpleJPARepository postSimpleJPARepository;
+    private final PostQueryRepository postQueryRepository;
     private final ImageService imageService;
     private final LikesRedisService likesRedisService;
 
@@ -35,7 +38,11 @@ public class PostService {
                 .image(image)
                 .build();
 
-        return postRepository.save(post);
+        if(postRequest.hashtags() != null) {
+            post.addHashtags(postRequest.hashtags());
+        }
+
+        return postSimpleJPARepository.save(post);
     }
 
     @Transactional
@@ -47,21 +54,21 @@ public class PostService {
         }
 
         if(!Objects.equals(post.getImage().getId(), postRequest.imageId())) {
+            imageService.delete(post.getImage());
+
             Image image = imageService.findById(postRequest.imageId());
-            post.update(postRequest.content(), image);
-        } else if (postRequest.imageId() == null) {
-            post.update(postRequest.content(), null);
+            return post.update(postRequest.content(), image, postRequest.hashtags());
         }
 
-        return post;
+        return post.update(postRequest.content(), postRequest.hashtags());
     }
 
     public Page<Post> findAll(Pageable pageable) {
-        return postRepository.findAll(pageable);
+        return postSimpleJPARepository.findAll(pageable);
     }
 
     public Post findById(Long id) {
-        return postRepository.findById(id)
+        return postSimpleJPARepository.findById(id)
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.POST_NOT_FOUND, String.format("해당 게시글(%s)을 찾을 수 없습니다.", id)));
     }
 
@@ -74,7 +81,7 @@ public class PostService {
         }
 
         imageService.delete(post.getImage());
-        postRepository.delete(post);
+        postSimpleJPARepository.delete(post);
         likesRedisService.deleteLikesPost(id);
     }
 

--- a/module-api/src/main/java/com/codingbottle/domain/post/service/PostService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/post/service/PostService.java
@@ -85,6 +85,10 @@ public class PostService {
         likesRedisService.deleteLikesPost(id);
     }
 
+    public List<Post> searchByKeyword(String keyword) {
+        return postQueryRepository.searchByKeyword(keyword);
+    }
+
     private boolean isNotSameWriter(Post post, User user) {
         return !post.getUser().equals(user);
     }

--- a/module-api/src/main/java/com/codingbottle/domain/region/service/RegionService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/region/service/RegionService.java
@@ -11,9 +11,7 @@ import java.util.stream.Collectors;
 @Service
 public class RegionService {
     public Map<String, String> findAll() {
-        List<Region> regions = Arrays.asList(Region.values());
-
-        return regions.stream()
+        return Arrays.stream(Region.values())
                 .filter(region -> !region.equals(Region.NONE))
                 .sorted(Comparator.comparing(Region::getCode))
                 .collect(Collectors.toMap(Region::name, Region::getDetail, (oldValue, newValue) -> oldValue, LinkedHashMap::new));

--- a/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
@@ -70,6 +70,7 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("content").description("게시물 리스트"),
                                 fieldWithPath("content[].id").description("게시물 id").type("Number"),
                                 fieldWithPath("content[].content").description("게시물 내용"),
+                                fieldWithPath("content[].hashtags").description("게시물 해시태그"),
                                 fieldWithPath("content[].writerNickname").description("게시물 작성자"),
                                 fieldWithPath("content[].likeCount").description("게시물 좋아요 수"),
                                 fieldWithPath("content[].likeStatus").description("게시물 좋아요 여부"),
@@ -113,7 +114,8 @@ class PostControllerTest extends RestDocsTest {
                         getAuthorizationHeader(),
                         requestFields(
                                 fieldWithPath("content").description("게시물 내용 (필수)"),
-                                fieldWithPath("imageId").description("게시물 이미지 id (필수)")
+                                fieldWithPath("imageId").description("게시물 이미지 id (필수)"),
+                                fieldWithPath("hashtags").description("게시물 해시태그 (선택)")
                         ),
                         getPostResponseFields()));
     }
@@ -192,10 +194,44 @@ class PostControllerTest extends RestDocsTest {
                                 parameterWithName("id").description("게시물 id"))));
     }
 
+    @Test
+    @DisplayName("게시글 검색")
+    void search_keyword() throws Exception{
+        //given
+        given(postService.searchByKeyword(any(String.class))).willReturn(List.of(게시글1, 게시글2));
+        //when & then
+        mvc.perform(get(REQUEST_URL + "/search")
+                        .queryParam("keyword", "검색어")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk())
+                .andDo(document("search-keyword",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        getAuthorizationHeader(),
+                        queryParameters(
+                                parameterWithName("keyword").description("검색어")),
+                        responseFields(
+                                fieldWithPath("[]").description("게시물 리스트"),
+                                fieldWithPath("[].id").description("게시물 id").type("Number"),
+                                fieldWithPath("[].content").description("게시물 내용"),
+                                fieldWithPath("[].hashtags").description("게시물 해시태그"),
+                                fieldWithPath("[].writerNickname").description("게시물 작성자"),
+                                fieldWithPath("[].likeCount").description("게시물 좋아요 수"),
+                                fieldWithPath("[].likeStatus").description("게시물 좋아요 여부"),
+                                fieldWithPath("[].image").description("게시물 이미지"),
+                                fieldWithPath("[].image.id").description("게시물 이미지 id"),
+                                fieldWithPath("[].image.imageUrl").description("게시물 이미지 url"),
+                                fieldWithPath("[].createdTime").description("게시물 생성시간").type("LocalDateTime"),
+                                fieldWithPath("[].modifiedTime").description("게시물 수정시간").type("LocalDateTime")
+                        )));
+    }
+
     private ResponseFieldsSnippet getPostResponseFields() {
         return responseFields(
                 fieldWithPath("id").description("게시물 id").type("Number"),
                 fieldWithPath("content").description("게시물 내용"),
+                fieldWithPath("hashtags").description("게시물 해시태그"),
                 fieldWithPath("writerNickname").description("게시물 작성자 명"),
                 fieldWithPath("likeCount").description("게시물 좋아요 수"),
                 fieldWithPath("likeStatus").description("게시물 좋아요 여부"),

--- a/module-api/src/test/java/com/codingbottle/domain/region/service/RegionServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/region/service/RegionServiceTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.stream.Collectors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("RegionService 테스트")
@@ -20,11 +25,16 @@ class RegionServiceTest {
     @Test
     @DisplayName("지역 목록 조회")
     void find_all_regions() {
-        // given & when
+        //when
         var regions = regionService.findAll();
 
+        LinkedHashMap<String, String> expected  = Arrays.stream(Region.values())
+                .filter(region -> !region.equals(Region.NONE))
+                .sorted(Comparator.comparing(Region::getCode))
+                .collect(Collectors.toMap(Region::name, Region::getDetail, (oldValue, newValue) -> oldValue, LinkedHashMap::new));
+
         // then
-        assertThat(regions).isNotEmpty();
+        assertThat(regions).isEqualTo(expected);
     }
 
     @Test
@@ -43,5 +53,4 @@ class RegionServiceTest {
         // then
         assertThat(updateUser.getRegion()).isEqualTo(region);
     }
-
 }

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -19,16 +19,26 @@ import com.codingbottle.domain.region.entity.Region;
 import com.codingbottle.domain.user.model.UserNicknameRequest;
 
 import java.util.HashMap;
+import java.util.List;
 
 
 public class DomainFixture {
     public static final Image 게시글1_이미지 = Image.builder()
+            .id(1L)
             .directory(Directory.POST)
             .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
             .convertImageName("default.png")
             .build();
 
     public static final Image 게시글2_이미지 = Image.builder()
+            .id(2L)
+            .directory(Directory.POST)
+            .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
+            .convertImageName("default.png")
+            .build();
+
+    public static final Image 게시글3_이미지 = Image.builder()
+            .id(3L)
             .directory(Directory.POST)
             .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
             .convertImageName("default.png")
@@ -62,11 +72,29 @@ public class DomainFixture {
             .user(유저1)
             .build();
 
-    public static final PostRequest 게시글_생성_요청1 = new PostRequest("게시글", 1L);
+    public static final Post 게시글3 = Post.builder()
+            .content("게시글")
+            .image(게시글3_이미지)
+            .user(유저1)
+            .build();
 
-    public static final PostRequest 게시글_수정_요청1 = new PostRequest("게시글 수정", 1L);
+    public static final PostRequest 게시글_생성_요청1 = new PostRequest("게시글", 1L, List.of("해시태그"));
+
+    public static final PostRequest 게시글_생성_요청2 = new PostRequest("게시글", 3L, null);
+
+    public static final PostRequest 게시글_수정_요청1 = new PostRequest("게시글 수정", 1L, List.of("해시태그"));
+
+    public static final PostRequest 게시글_수정_요청2 = new PostRequest("게시글 수정", 4L, List.of("해시태그"));
 
     public static final Image 게시글_수정_이미지1 = Image.builder()
+            .id(3L)
+            .directory(Directory.POST)
+            .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
+            .convertImageName("default.png")
+            .build();
+
+    public static final Image 게시글_수정_이미지2 = Image.builder()
+            .id(4L)
             .directory(Directory.POST)
             .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
             .convertImageName("default.png")

--- a/module-core/src/main/java/com/codingbottle/domain/post/entity/Post.java
+++ b/module-core/src/main/java/com/codingbottle/domain/post/entity/Post.java
@@ -18,12 +18,17 @@ import java.util.List;
 public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "post_num")
+    @Column(name = "post_id")
     private Long id;
 
     @Lob
     @Column(name = "post_content")
     private String content;
+
+    @ElementCollection
+    @CollectionTable(name = "post_hashtags", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "hashtag")
+    private List<String> hashtags = new ArrayList<>(5);
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -43,9 +48,17 @@ public class Post extends BaseEntity {
         this.image = image;
     }
 
-    public void update(String content, Image image) {
+    public Post update(String content, Image image, List<String> hashtags) {
         this.content = content;
         this.image = image;
+        this.hashtags = hashtags;
+        return this;
+    }
+
+    public Post update(String content, List<String> hashtags) {
+        this.content = content;
+        this.hashtags = hashtags;
+        return this;
     }
 
     public void addLikes(UserPostLikes userPostLikes) {
@@ -54,5 +67,9 @@ public class Post extends BaseEntity {
 
     public void removeLikes(User user) {
         this.likes.removeIf(likes -> likes.getUser().equals(user));
+    }
+
+    public void addHashtags(List<String> hashtags) {
+        this.hashtags.addAll(hashtags);
     }
 }

--- a/module-core/src/main/java/com/codingbottle/domain/post/repo/PostQueryRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/post/repo/PostQueryRepository.java
@@ -1,0 +1,22 @@
+package com.codingbottle.domain.post.repo;
+
+import com.codingbottle.domain.post.entity.Post;
+import com.codingbottle.domain.post.entity.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QPost qPost = QPost.post;
+
+    public List<Post> searchByKeyword(String keyword) {
+        return jpaQueryFactory.selectFrom(qPost)
+                .where(qPost.hashtags.contains(keyword))
+                .fetch();
+    }
+}

--- a/module-core/src/main/java/com/codingbottle/domain/post/repo/PostRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/post/repo/PostRepository.java
@@ -1,9 +1,0 @@
-package com.codingbottle.domain.post.repo;
-
-import com.codingbottle.domain.post.entity.Post;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
-}

--- a/module-core/src/main/java/com/codingbottle/domain/post/repo/PostSimpleJPARepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/post/repo/PostSimpleJPARepository.java
@@ -1,0 +1,9 @@
+package com.codingbottle.domain.post.repo;
+
+import com.codingbottle.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostSimpleJPARepository extends JpaRepository<Post, Long> {
+}

--- a/module-core/src/test/java/com/codingbottle/common/config/TestQueryDslConfig.java
+++ b/module-core/src/test/java/com/codingbottle/common/config/TestQueryDslConfig.java
@@ -1,5 +1,6 @@
 package com.codingbottle.common.config;
 
+import com.codingbottle.domain.post.repo.PostQueryRepository;
 import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
 import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -28,5 +29,10 @@ public class TestQueryDslConfig {
     @Bean
     public UserQuizQueryRepository userQuizRepository() {
         return new UserQuizQueryRepository(jpaQueryFactory());
+    }
+
+    @Bean
+    public PostQueryRepository postQueryRepository() {
+        return new PostQueryRepository(jpaQueryFactory());
     }
 }

--- a/module-core/src/test/java/com/codingbottle/domain/post/entity/PostTest.java
+++ b/module-core/src/test/java/com/codingbottle/domain/post/entity/PostTest.java
@@ -1,0 +1,125 @@
+package com.codingbottle.domain.post.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.codingbottle.fixture.CoreDomainFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostTest {
+    private static final String CONTENT = "게시글 내용";
+
+    @Test
+    @DisplayName("게시글 객체를 빌더 패턴을 이용하여 생성한다.")
+    void create_post_with_builder() {
+        // when
+        Post post = Post.builder()
+                .content(CONTENT)
+                .user(유저1)
+                .image(게시글_이미지1)
+                .build();
+        // then
+        assertAll(
+                () -> assertEquals(CONTENT, post.getContent()),
+                () -> assertEquals(유저1, post.getUser()),
+                () -> assertEquals(게시글_이미지1, post.getImage())
+        );
+    }
+
+    @Test
+    @DisplayName("게시글의 내용과 해시태그를 수정한다.")
+    void update_post() {
+        // given
+        Post post = Post.builder()
+                .content(CONTENT)
+                .user(유저1)
+                .image(게시글_이미지1)
+                .build();
+        // when
+        post.update("수정된 게시글 내용", List.of("해시태그1", "해시태그2"));
+        // then
+        assertAll(
+                () -> assertEquals("수정된 게시글 내용", post.getContent()),
+                () -> assertEquals(2, post.getHashtags().size())
+        );
+    }
+
+    @Test
+    @DisplayName("게시글의 내용과 해시태그, 이미지를 수정한다.")
+    void update_post_with_image() {
+        // given
+        Post post = Post.builder()
+                .content(CONTENT)
+                .user(유저1)
+                .image(게시글_이미지1)
+                .build();
+        // when
+        post.update("수정된 게시글 내용", 게시글_이미지2, List.of("해시태그1", "해시태그2"));
+        // then
+        assertAll(
+                () -> assertEquals("수정된 게시글 내용", post.getContent()),
+                () -> assertEquals(게시글_이미지2, post.getImage()),
+                () -> assertEquals(2, post.getHashtags().size())
+        );
+    }
+
+    @Test
+    @DisplayName("게시글의 해시태그를 추가한다.")
+    void add_hashtags() {
+        // given
+        Post post = Post.builder()
+                .content(CONTENT)
+                .user(유저1)
+                .image(게시글_이미지1)
+                .build();
+        // when
+        post.addHashtags(List.of("해시태그1", "해시태그2"));
+        // then
+        assertAll(
+                () -> assertEquals(2, post.getHashtags().size())
+        );
+    }
+
+    @Test
+    @DisplayName("게시글의 좋아요를 추가한다.")
+    void add_likes() {
+        // given
+        Post post = Post.builder()
+                .content(CONTENT)
+                .user(유저1)
+                .image(게시글_이미지1)
+                .build();
+        // when
+        post.addLikes(UserPostLikes.builder()
+                .user(유저1)
+                .post(post)
+                .build());
+        // then
+        assertAll(
+                () -> assertEquals(1, post.getLikes().size())
+        );
+    }
+
+    @Test
+    @DisplayName("게시글의 좋아요를 삭제한다.")
+    void remove_likes() {
+        // given
+        Post post = Post.builder()
+                .content(CONTENT)
+                .user(유저1)
+                .image(게시글_이미지1)
+                .build();
+        post.addLikes(UserPostLikes.builder()
+                .user(유저1)
+                .post(post)
+                .build());
+        // when
+        post.removeLikes(유저1);
+        // then
+        assertAll(
+                () -> assertEquals(0, post.getLikes().size())
+        );
+    }
+}

--- a/module-core/src/test/java/com/codingbottle/domain/post/repo/PostQueryRepositoryTest.java
+++ b/module-core/src/test/java/com/codingbottle/domain/post/repo/PostQueryRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.codingbottle.domain.post.repo;
+
+import com.codingbottle.auth.repository.UserRepository;
+import com.codingbottle.common.annotation.RepositoryTest;
+import com.codingbottle.domain.image.repo.ImageRepository;
+import com.codingbottle.domain.post.entity.Post;
+import com.codingbottle.fixture.CoreDomainFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@RepositoryTest
+class PostQueryRepositoryTest {
+    @Autowired
+    private PostSimpleJPARepository postSimpleJPARepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostQueryRepository postQueryRepository;
+
+    Post 게시글1;
+    Post 게시글2;
+    @BeforeEach
+    void setUp() {
+        userRepository.save(CoreDomainFixture.유저1);
+        imageRepository.saveAll(List.of(CoreDomainFixture.게시글_이미지1, CoreDomainFixture.게시글_이미지2));
+        게시글1 = postSimpleJPARepository.save(CoreDomainFixture.게시글1);
+        게시글2 = postSimpleJPARepository.save(CoreDomainFixture.게시글2);
+
+        게시글1.addHashtags(List.of("해시태그1", "해시태그2"));
+        게시글2.addHashtags(List.of("해시태그3", "해시태그4"));
+    }
+
+    @Test
+    @DisplayName("해시태그 검색어로 게시글을 검색한다.")
+    void search_post_by_hashtag() {
+        // when
+        List<Post> post = postQueryRepository.searchByKeyword("해시태그1");
+        // then
+        Assertions.assertThat(post).contains(게시글1);
+    }
+}

--- a/module-core/src/test/java/com/codingbottle/fixture/CoreDomainFixture.java
+++ b/module-core/src/test/java/com/codingbottle/fixture/CoreDomainFixture.java
@@ -2,6 +2,9 @@ package com.codingbottle.fixture;
 
 import com.codingbottle.auth.entity.Role;
 import com.codingbottle.auth.entity.User;
+import com.codingbottle.domain.image.entity.Directory;
+import com.codingbottle.domain.image.entity.Image;
+import com.codingbottle.domain.post.entity.Post;
 import com.codingbottle.domain.quiz.entity.Quiz;
 import com.codingbottle.domain.quiz.entity.QuizStatus;
 import com.codingbottle.domain.quiz.entity.QuizType;
@@ -65,5 +68,31 @@ public class CoreDomainFixture {
             .user(유저1)
             .quiz(퀴즈2)
             .quizStatus(QuizStatus.WRONG)
+            .build();
+
+    public static final Image 게시글_이미지1 = Image.builder()
+            .id(1L)
+            .directory(Directory.POST)
+            .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
+            .convertImageName("default.png")
+            .build();
+
+    public static final Image 게시글_이미지2 = Image.builder()
+            .id(2L)
+            .directory(Directory.POST)
+            .imageUrl("https://d1csu9i9ktup9e.cloudfront.net/default.png")
+            .convertImageName("default.png")
+            .build();
+
+    public static final Post 게시글1 = Post.builder()
+            .content("게시글")
+            .image(게시글_이미지1)
+            .user(유저1)
+            .build();
+
+    public static final Post 게시글2 = Post.builder()
+            .content("게시글")
+            .image(게시글_이미지2)
+            .user(유저1)
             .build();
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #72


## :bulb: 상세 내용:
- 게시물에 해시태그 프로퍼티 추가
- QueryDsl을 이용한 검색 기능 추가
- 일부 테스트 코드 추가
