### PR TITLE
게시글(Post)에 캐시를 적용하여 성능 개선

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -30,6 +30,7 @@ configurations {
 dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     implementation project(':module-core')
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.1.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.2'
     implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'

--- a/module-api/src/main/java/com/codingbottle/common/config/CacheConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/config/CacheConfig.java
@@ -1,0 +1,21 @@
+package com.codingbottle.common.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager concurrentMapCacheManager = new ConcurrentMapCacheManager();
+        concurrentMapCacheManager.setAllowNullValues(false);
+        concurrentMapCacheManager.setCacheNames(List.of("posts"));
+        return concurrentMapCacheManager;
+    }
+}

--- a/module-api/src/main/java/com/codingbottle/common/redis/config/LikeRedisConfig.java
+++ b/module-api/src/main/java/com/codingbottle/common/redis/config/LikeRedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories(redisTemplateRef = "likesRedisTemplate")
@@ -17,6 +18,8 @@ public class LikeRedisConfig extends RedisConfig {
     @Bean
     public RedisTemplate<Long, Long> likesRedisTemplate() {
         RedisTemplate<Long, Long>  template = new RedisTemplate<>();
+        template.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         template.setConnectionFactory(deviceControlRedisConnectionFactory());
         template.afterPropertiesSet();
         return template;

--- a/module-api/src/main/java/com/codingbottle/common/util/PagingUtil.java
+++ b/module-api/src/main/java/com/codingbottle/common/util/PagingUtil.java
@@ -1,0 +1,24 @@
+package com.codingbottle.common.util;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PagingUtil {
+    public static <T> SliceImpl<T> toSliceImpl(List<T> items, Pageable pageable) {
+        boolean hasNext = false;
+
+        if (items.size() > pageable.getPageSize()) {
+            items.remove(items.size() - 1);
+            hasNext = true;
+        }
+
+        if(items.isEmpty()) {
+            items = new ArrayList<>();
+        }
+        return new SliceImpl<>(items, pageable, hasNext);
+    }
+}
+

--- a/module-api/src/test/java/com/codingbottle/common/util/PagingUtilTest.java
+++ b/module-api/src/test/java/com/codingbottle/common/util/PagingUtilTest.java
@@ -1,0 +1,54 @@
+package com.codingbottle.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PagingUtilTest {
+    @Test
+    @DisplayName("페이징 처리 시 items의 size가 pageSize보다 작으면 hasNext는 false이다.")
+    void if_items_size_is_less_than_pageSize_then_hasNext_is_false() {
+        // given
+        List<String> items = List.of("1", "2", "3");
+        PageRequest pageable = PageRequest.of(0, 10);
+        // when
+        SliceImpl<String> slice = PagingUtil.toSliceImpl(items, pageable);
+        // then
+        assertThat(slice.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("페이징 처리 시 items의 size가 pageSize보다 크면 hasNext는 true이이고 items의 마지막 요소는 제거된다.")
+    void if_items_size_is_greater_than_pageSize_then_hasNext_is_true_and_last_item_is_removed() {
+        // given
+        List<String> items = new ArrayList<>(List.of("1", "2", "3", "4", "5", "6"));
+        PageRequest pageable = PageRequest.of(0, 5);
+        // when
+        SliceImpl<String> slice = PagingUtil.toSliceImpl(items, pageable);
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isTrue(),
+                () -> assertThat(slice.getContent()).hasSize(5),
+                () -> assertThat(slice.getContent().get(4)).isEqualTo("5")
+        );
+    }
+
+    @Test
+    @DisplayName("페이징 처리 시 items가 비어있으면 hasNext는 false이다.")
+    void if_items_is_empty_then_hasNext_is_false() {
+        // given
+        List<String> items = new ArrayList<>();
+        PageRequest pageable = PageRequest.of(0, 5);
+        // when
+        SliceImpl<String> slice = PagingUtil.toSliceImpl(items, pageable);
+        // then
+        assertThat(slice.hasNext()).isFalse();
+    }
+}

--- a/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/post/controller/PostControllerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -44,7 +43,7 @@ class PostControllerTest extends RestDocsTest {
     @Test
     void find_all_posts() throws Exception{
         //given
-        given(postService.findAll(any(PageRequest.class))).willReturn(new PageImpl<>(List.of(게시글1, 게시글2)));
+        given(postService.findAll(any(PageRequest.class))).willReturn(List.of(게시글1, 게시글2));
         //when & then
         mvc.perform(get(REQUEST_URL)
                         .queryParam("page", "0")
@@ -52,10 +51,6 @@ class PostControllerTest extends RestDocsTest {
                         .queryParam("sort", "modifiedTime,desc")
                         .header("Authorization", "Bearer FirebaseToken"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").exists())
-                .andExpect(jsonPath("$.totalPages").exists())
-                .andExpect(jsonPath("$.totalElements").exists())
-                .andExpect(jsonPath("$.size").exists())
                 .andDo(document("posts-list",
                         getDocumentRequest(),
                         getDocumentResponse(),
@@ -80,18 +75,25 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("content[].createdTime").description("게시물 생성시간").type("LocalDateTime"),
                                 fieldWithPath("content[].modifiedTime").description("게시물 수정시간").type("LocalDateTime"),
                                 fieldWithPath("pageable").description("페이지 정보"),
+                                fieldWithPath("pageable.pageNumber").description("페이지 번호"),
+                                fieldWithPath("pageable.pageSize").description("페이지 사이즈"),
+                                fieldWithPath("pageable.sort").description("정렬 방식"),
+                                fieldWithPath("pageable.sort.empty").description("페이징 정렬 방식 (빈 값)"),
+                                fieldWithPath("pageable.sort.sorted").description("페이징 정렬 유무"),
+                                fieldWithPath("pageable.sort.unsorted").description("페이징 정렬 유무"),
+                                fieldWithPath("pageable.offset").description("페이지 offset"),
+                                fieldWithPath("pageable.paged").description("페이지 여부"),
+                                fieldWithPath("pageable.unpaged").description("페이지 여부"),
+                                fieldWithPath("first").description("첫번째 페이지 여부"),
                                 fieldWithPath("last").description("마지막 페이지 여부"),
-                                fieldWithPath("totalElements").description("전체 요소 수"),
-                                fieldWithPath("totalPages").description("전체 페이지 수"),
-                                fieldWithPath("size").description("페이지 크기"),
-                                fieldWithPath("number").description("현재 페이지 번호"),
-                                fieldWithPath("sort.empty").description("정렬되지 않은 경우"),
-                                fieldWithPath("sort.sorted").description("정렬된 경우"),
-                                fieldWithPath("sort.unsorted").description("정렬되지 않은 경우"),
-                                fieldWithPath("first").description("첫 페이지 여부"),
-                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
-                                fieldWithPath("empty").description("데이터가 비어 있는지 여부")
-                        )));
+                                fieldWithPath("size").description("페이지 사이즈"),
+                                fieldWithPath("number").description("페이지 번호"),
+                                fieldWithPath("sort").description("정렬 방식"),
+                                fieldWithPath("sort.empty").description("정렬 여부"),
+                                fieldWithPath("sort.sorted").description("정렬 여부"),
+                                fieldWithPath("sort.unsorted").description("정렬 여부"),
+                                fieldWithPath("numberOfElements").description("페이지 요소 수"),
+                                fieldWithPath("empty").description("페이지 여부"))));
     }
 
     @DisplayName("게시글 생성")

--- a/module-api/src/test/java/com/codingbottle/domain/post/service/PostServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/post/service/PostServiceTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
@@ -128,11 +126,11 @@ class PostServiceTest {
         // given
         PageRequest pageRequest = PageRequest.of(0, 10);
 
-        given(postSimpleJPARepository.findAll(any(PageRequest.class))).willReturn(new PageImpl<>(List.of(게시글1)));
+        given(postQueryRepository.finAll(any(PageRequest.class))).willReturn(List.of(게시글1, 게시글2));
         // when
-        Page<Post> posts = postService.findAll(pageRequest);
+        List<Post> posts = postService.findAll(pageRequest);
         // then
-        assertThat(posts).containsExactly(게시글1);
+        assertThat(posts).contains(게시글1, 게시글2);
     }
 
     @Test

--- a/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/ApplicationErrorType.java
@@ -13,6 +13,7 @@ public enum ApplicationErrorType {
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST, "Firebase 토큰이 올바르지 않습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "파일 타입이 올바르지 않습니다."),
     NOT_EXIT_WRONG_ANSWER(HttpStatus.BAD_REQUEST, "틀린 문제가 없습니다."),
+    INVALID_DATA_ACCESS(HttpStatus.BAD_REQUEST, "데이터 접근이 올바르지 않습니다."),
     //401
     NO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     //403
@@ -30,7 +31,8 @@ public enum ApplicationErrorType {
     FAIL_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패하였습니다"),
     REDIS_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 삭제에 실패하였습니다."),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시만 기달려주세요."),
-    JSON_PROCESSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 처리 중 에러가 발생했습니다." );
+    JSON_PROCESSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 처리 중 에러가 발생했습니다."),
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/module-core/src/main/java/com/codingbottle/common/exception/GlobalExceptionHandler.java
+++ b/module-core/src/main/java/com/codingbottle/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.google.api.pathtemplate.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.context.annotation.Primary;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -21,6 +22,13 @@ public class GlobalExceptionHandler {
         log.error("ApplicationErrorException {}", e.getMessage());
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(e.getApplicationErrorType().name(), e.getMessage());
         return new ResponseEntity<>(errorResponseDto, e.getApplicationErrorType().getHttpStatus());
+    }
+
+    @ExceptionHandler(value = InvalidDataAccessApiUsageException.class)
+    public ResponseEntity<ErrorResponseDto> handleInvalidDataAccessApiUsageException(WebRequest request, InvalidDataAccessApiUsageException e) {
+        log.error("InvalidDataAccessApiUsageException {}", e.getMessage());
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(ApplicationErrorType.INVALID_DATA_ACCESS.name(), e.getMessage());
+        return new ResponseEntity<>(errorResponseDto, ApplicationErrorType.INTERNAL_ERROR.getHttpStatus());
     }
 
     @ExceptionHandler(value = ValidationException.class)

--- a/module-core/src/main/java/com/codingbottle/domain/post/repo/PostQueryRepository.java
+++ b/module-core/src/main/java/com/codingbottle/domain/post/repo/PostQueryRepository.java
@@ -2,8 +2,11 @@ package com.codingbottle.domain.post.repo;
 
 import com.codingbottle.domain.post.entity.Post;
 import com.codingbottle.domain.post.entity.QPost;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,11 +15,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
-    private final QPost qPost = QPost.post;
+    private final QPost post = QPost.post;
 
     public List<Post> searchByKeyword(String keyword) {
-        return jpaQueryFactory.selectFrom(qPost)
-                .where(qPost.hashtags.contains(keyword))
+        return jpaQueryFactory.selectFrom(post)
+                .where(post.hashtags.contains(keyword))
+                .fetch();
+    }
+
+    public List<Post> finAll(Pageable pageable) {
+        return jpaQueryFactory.selectFrom(post)
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .orderBy(new OrderSpecifier[]{new OrderSpecifier<>(Order.DESC, post.createdTime)})
                 .fetch();
     }
 }

--- a/module-core/src/test/java/com/codingbottle/domain/post/repo/PostQueryRepositoryTest.java
+++ b/module-core/src/test/java/com/codingbottle/domain/post/repo/PostQueryRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -47,5 +48,23 @@ class PostQueryRepositoryTest {
         List<Post> post = postQueryRepository.searchByKeyword("해시태그1");
         // then
         Assertions.assertThat(post).contains(게시글1);
+    }
+
+    @Test
+    @DisplayName("페이징 처리된 게시글을 조회한다. (최근 저장된 순)")
+    void find_all_post_with_paging() {
+        // when
+        List<Post> posts = postQueryRepository.finAll(PageRequest.of(0, 1));
+        // then
+        Assertions.assertThat(posts).contains(게시글2);
+    }
+
+    @Test
+    @DisplayName("페이징에 따라 반환 게시글 갯수가 드르게 된다.")
+    void find_all_post_with_paging_by_page_size() {
+        // when
+        List<Post> posts = postQueryRepository.finAll(PageRequest.of(0, 2));
+        // then
+        Assertions.assertThat(posts).contains(게시글1, 게시글2);
     }
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #74  #


## :bulb: 상세 내용:
- 글로버 예외 처리 추가 (Invalid Data Access Exception)
- 캐시를 이용하여 게시글 모두 조회 캐싱
- 페이징 구현체 변경 (Page -> Slice)
- queryDsl을 이용하여 모두 조회시 페이징을 적용한 동적 쿼리 작성
