### PR TITLE
사용자 랭킹 조회시 사용자의 점수가 Redis에 저장이 되어 있지 않을 경우 오류 발생 

### DIFF
--- a/module-api/src/docs/asciidoc/랭킹-API.adoc
+++ b/module-api/src/docs/asciidoc/랭킹-API.adoc
@@ -17,4 +17,7 @@ operation::rank-list[snippets='http-request,http-response,response-fields']
 
 [[나의-랭킹-조회]]
 == 나의 랭킹 조회
+
+만약 유저가 퀴즈를 푼적이 없거나 점수가 0이면 랭킹이 0등으로 나온다.
+
 operation::user-rank[snippets='http-request,http-response,response-fields']

--- a/module-api/src/docs/asciidoc/퀴즈-API.adoc
+++ b/module-api/src/docs/asciidoc/퀴즈-API.adoc
@@ -15,7 +15,7 @@ operation::quiz-list[snippets='http-request,query-parameters,http-response,respo
 
 [[퀴즈-결과-]]
 == 퀴즈 결과 전송
-operation::put-quiz-status[snippets='http-request,path-parameters,request-body,request-fields,http-response,response-fields']
+operation::put-quiz-status[snippets='http-request,path-parameters,request-body,request-fields,http-response,response-body']
 
 [[틀린퀴즈-조회]]
 == 틀린 퀴즈 조회

--- a/module-api/src/main/java/com/codingbottle/common/redis/service/QuizRankRedisService.java
+++ b/module-api/src/main/java/com/codingbottle/common/redis/service/QuizRankRedisService.java
@@ -105,7 +105,8 @@ public class QuizRankRedisService {
     }
 
     private Long getRank(CacheUser cacheUser) {
-        return zSetOperations.rank(QUIZ_RANK_KEY, convertToJson(cacheUser));
+        Long rank = zSetOperations.rank(QUIZ_RANK_KEY, convertToJson(cacheUser));
+        return Optional.ofNullable(rank).orElse(-1L);
     }
 }
 

--- a/module-api/src/main/java/com/codingbottle/domain/weather/controller/WeatherController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/weather/controller/WeatherController.java
@@ -21,7 +21,6 @@ public class WeatherController {
     @GetMapping("/weather")
     public ResponseEntity<WeatherResponse> getCurrentWeather(@AuthenticationPrincipal User user) {
         WeatherResponse weather = weatherService.getWeather(user);
-
         return ResponseEntity.ok(weather);
     }
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #82 
 

## :bulb: 상세 내용:
- Optional을 이용하여 null값이면 디폴트 값을 넣어주도록 변경
- API 문서 수정