### PR TITLE
퀴즈 서비스 로직 수정

### DIFF
--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/QuizStatusRequest.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/QuizStatusRequest.java
@@ -3,11 +3,15 @@ package com.codingbottle.domain.quiz.model;
 import com.codingbottle.domain.quiz.entity.QuizStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "퀴즈 상태 변경 요청")
 public record QuizStatusRequest(
         @NotBlank
         @Schema(description = "퀴즈 정답시 CORRECT, 오답시 WRONG", example = "CORRECT")
-        QuizStatus quizStatus
+        QuizStatus quizStatus,
+        @NotNull
+        @Schema(description = "Type을 보내야 해당 퀴즈의 점수를 차등 부여할 수 있기 때문에 Type을 보내주세요", example = "TODAY")
+        Type type
 ) {
 }

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
@@ -3,22 +3,30 @@ package com.codingbottle.domain.quiz.model;
 import com.codingbottle.domain.user.entity.User;
 import com.codingbottle.domain.quiz.entity.Quiz;
 import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
+import lombok.Getter;
 
 import java.util.List;
 
 public enum Type {
-    TODAY{
+    TODAY(10){
         @Override
         public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
             return quizRepository.findRandomQuizzes(user, 3);
         }
     },
-    NORMAL{
+    NORMAL(5){
         @Override
         public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
             return quizRepository.findRandomWrongQuizzes(user, 10);
         }
     };
+
+    @Getter
+    final int score;
+
+    Type(int score) {
+        this.score = score;
+    }
 
     public abstract List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository);
 }

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/restapi/QuizApi.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/restapi/QuizApi.java
@@ -19,7 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/quiz")
 public interface QuizApi {
-    @Operation(summary = "퀴즈 목록 조회", description = "Type에 맞는 퀴즈 목록을 조회합니다.")
+    @Operation(summary = "퀴즈 목록 조회", description = "Type에 맞는 퀴즈 목록을 조회합니다. (오늘의 퀴즈를 이미 푼 사용자는 에러 메시지가 반환됩니다.")
     @GetMapping
     List<QuizResponse> getQuizList(
             User user,

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/service/QuizService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/service/QuizService.java
@@ -8,6 +8,7 @@ import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
 import com.codingbottle.domain.quiz.repo.QuizSimpleJPARepository;
 import com.codingbottle.exception.ApplicationErrorException;
 import com.codingbottle.exception.ApplicationErrorType;
+import com.codingbottle.redis.domain.quiz.service.TodayQuizRedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,8 +22,13 @@ import java.util.stream.Collectors;
 public class QuizService {
     private final QuizQueryRepository quizRepository;
     private final QuizSimpleJPARepository quizSimpleJPARepository;
+    private final TodayQuizRedisService todayQuizRedisService;
 
     public List<QuizResponse> findByType(User user, Type type) {
+        if (type.equals(Type.TODAY) && todayQuizRedisService.isAlreadySolved(user.getId())) {
+            throw new ApplicationErrorException(ApplicationErrorType.ALREADY_SOLVED_TODAY_QUIZ, "오늘의 퀴즈를 이미 푼 사용자입니다.");
+        }
+
         return type.getQuizzes(user, quizRepository).stream()
                 .map(QuizResponse::from)
                 .collect(Collectors.toList());

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
@@ -99,7 +99,8 @@ class UserQuizControllerTest extends RestDocsTest {
                                 parameterWithName("id").description("퀴즈 ID")
                         ),
                         requestFields(
-                                fieldWithPath("quizStatus").description("퀴즈 상태 (CORRECT / WRONG)")
+                                fieldWithPath("quizStatus").description("퀴즈 상태 (CORRECT / WRONG)"),
+                                fieldWithPath("type").description("오늘의 퀴즈인지, 그냥 퀴즈 풀이인지 전달 (TODAY / NORMAL)")
                         )));
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
@@ -4,6 +4,8 @@ import com.codingbottle.domain.quiz.model.QuizResponse;
 import com.codingbottle.domain.user.entity.User;
 import com.codingbottle.domain.quiz.model.Type;
 import com.codingbottle.domain.quiz.repo.QuizQueryRepository;
+import com.codingbottle.exception.ApplicationErrorException;
+import com.codingbottle.redis.domain.quiz.service.TodayQuizRedisService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static com.codingbottle.fixture.DomainFixture.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -26,6 +29,9 @@ class QuizServiceTest {
 
     @Mock
     private QuizQueryRepository quizRepository;
+
+    @Mock
+    private TodayQuizRedisService todayQuizRedisService;
 
     @Test
     @DisplayName("일반 퀴즈를 조회한다")
@@ -47,5 +53,15 @@ class QuizServiceTest {
         List<QuizResponse> quizzes = quizService.findByType(유저1, Type.TODAY);
         //then
         assertThat(quizzes.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("오늘의 퀴즈를 이미 푼 사용자는 오늘의 퀴즈를 조회할 수 없다")
+    void findByTodayQuizAndAlreadySolved(){
+        //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(true);
+        //when & then
+        assertThatThrownBy(() -> quizService.findByType(유저1, Type.TODAY))
+                .isInstanceOf(ApplicationErrorException.class);
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/UserQuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/UserQuizServiceTest.java
@@ -6,6 +6,7 @@ import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
 import com.codingbottle.domain.quiz.repo.UserQuizSimpleJPARepository;
 import com.codingbottle.exception.ApplicationErrorException;
 import com.codingbottle.redis.domain.quiz.service.QuizRankRedisService;
+import com.codingbottle.redis.domain.quiz.service.TodayQuizRedisService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,10 +41,15 @@ class UserQuizServiceTest {
     @Mock
     private QuizRankRedisService quizRankRedisService;
 
+    @Mock
+    private TodayQuizRedisService todayQuizRedisService;
+
     @Test
     @DisplayName("퀴즈 최초 풀이 시 정답일 경우 정답 처리 후 점수를 획득한다")
     void if_quiz_is_correct_then_update_quiz_status_and_get_10_points() {
         //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(false);
+
         given(userQuizSimpleJPARepository.existsByUserIdAndQuizId(any(), any())).willReturn(false);
 
         given(userQuizSimpleJPARepository.save(any())).willReturn(퀴즈_유저_정답1);
@@ -61,6 +67,8 @@ class UserQuizServiceTest {
     @DisplayName("퀴즈 최초 풀이 시 오답일 경우 오답 처리 후 점수를 획득하지 않는다")
     void if_quiz_is_wrong_then_update_quiz_status_and_get_0_points() {
         //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(false);
+
         given(userQuizSimpleJPARepository.existsByUserIdAndQuizId(any(), any())).willReturn(false);
 
         given(userQuizSimpleJPARepository.save(any())).willReturn(퀴즈_유저_오답1);
@@ -76,6 +84,8 @@ class UserQuizServiceTest {
     @DisplayName("이미 정답을 맞춘 퀴즈에 대해 정답을 맞추면 예외를 던진다")
     void if_quiz_is_already_correct_then_throw_exception() {
         //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(false);
+
         given(userQuizSimpleJPARepository.existsByUserIdAndQuizId(any(), any())).willReturn(true);
 
         given(userQuizSimpleJPARepository.findByUserIdAndQuizId(any(), any())).willReturn(Optional.ofNullable(퀴즈_유저_정답1));
@@ -88,6 +98,8 @@ class UserQuizServiceTest {
     @DisplayName("오답 처리시 이미 오답인 문제는 WRONG 상태를 유지한다")
     void if_quiz_is_already_wrong_then_keep_wrong_status() {
         //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(true);
+
         given(userQuizSimpleJPARepository.existsByUserIdAndQuizId(any(), any())).willReturn(true);
         //when
         String status = userQuizService.updateQuizStatus(퀴즈1.getId(), 퀴즈_오답_요청, 유저1);
@@ -99,6 +111,8 @@ class UserQuizServiceTest {
     @DisplayName("오답 처리된 퀴즈를 맞추게 되면 해당 퀴즈를 정답 처리하고 점수를 획득한다")
     void if_quiz_is_wrong_then_update_quiz_status_and_get_10_points() {
         //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(true);
+
         given(userQuizSimpleJPARepository.existsByUserIdAndQuizId(any(), any())).willReturn(true);
 
         given(userQuizSimpleJPARepository.findByUserIdAndQuizId(any(), any())).willReturn(Optional.ofNullable(퀴즈_유저_오답1));
@@ -140,5 +154,26 @@ class UserQuizServiceTest {
         UserQuizInfo userQuizInfo = userQuizService.getUserQuizInfo(유저1);
         //then
         assertThat(userQuizInfo.score()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("사용자가 처음 오늘의 퀴즈를 풀면 오늘의 퀴즈를 풀었음을 저장한다")
+    void if_user_solves_today_quiz_first_time_then_save_it() {
+        //given
+        given(todayQuizRedisService.isAlreadySolved(any())).willReturn(false);
+
+        given(userQuizSimpleJPARepository.existsByUserIdAndQuizId(any(), any())).willReturn(false);
+
+        given(userQuizSimpleJPARepository.save(any())).willReturn(퀴즈_유저_정답1);
+
+        given(quizService.findById(any())).willReturn(퀴즈1);
+
+        doNothing().when(todayQuizRedisService).setSolved(any());
+
+        doNothing().when(quizRankRedisService).updateScore(any(), any(Integer.class));
+        //when
+        String status = userQuizService.updateQuizStatus(퀴즈1.getId(), 퀴즈_정답_요청, 유저1);
+        //then
+        assertThat(status).isEqualTo("CORRECT");
     }
 }

--- a/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/codingbottle/fixture/DomainFixture.java
@@ -1,6 +1,7 @@
 package com.codingbottle.fixture;
 
 import com.codingbottle.domain.quiz.entity.UserQuiz;
+import com.codingbottle.domain.quiz.model.Type;
 import com.codingbottle.domain.user.entity.Role;
 import com.codingbottle.domain.user.entity.User;
 import com.codingbottle.domain.category.entity.Category;
@@ -148,9 +149,9 @@ public class DomainFixture {
             .image(퀴즈_이미지1)
             .build();
 
-    public static final QuizStatusRequest 퀴즈_정답_요청 = new QuizStatusRequest(QuizStatus.CORRECT);
+    public static final QuizStatusRequest 퀴즈_정답_요청 = new QuizStatusRequest(QuizStatus.CORRECT, Type.TODAY);
 
-    public static final QuizStatusRequest 퀴즈_오답_요청 = new QuizStatusRequest(QuizStatus.WRONG);
+    public static final QuizStatusRequest 퀴즈_오답_요청 = new QuizStatusRequest(QuizStatus.WRONG, Type.NORMAL);
 
     public static final UserQuiz 퀴즈_유저_정답1 = UserQuiz.builder()
             .id(1L)
@@ -186,7 +187,7 @@ public class DomainFixture {
 
     public static final InformationResponse 정보_응답1 = InformationResponse.from(정보1);
 
-    public static final QuizStatusRequest 퀴즈_결과_요청 = new QuizStatusRequest(QuizStatus.CORRECT);
+    public static final QuizStatusRequest 퀴즈_결과_요청 = new QuizStatusRequest(QuizStatus.CORRECT, Type.TODAY);
 
     public static final UserQuizInfo 퀴즈정보1 = new UserQuizInfo("닉네임", 10);
 

--- a/module-batch/src/main/java/com/codingbottle/domain/quiz/job/TodayQuizJobLauncher.java
+++ b/module-batch/src/main/java/com/codingbottle/domain/quiz/job/TodayQuizJobLauncher.java
@@ -1,0 +1,44 @@
+package com.codingbottle.domain.quiz.job;
+
+import com.codingbottle.domain.quiz.service.TodayQuizBatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class TodayQuizJobLauncher {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final TodayQuizBatchService todayQuizBatchService;
+
+    @Bean
+    public Job todayQuizJob() {
+        return new JobBuilder("todayQuizJob", jobRepository)
+                .start(todayQuizStep())
+                .preventRestart()
+                .build();
+    }
+
+    @Bean
+    public Step todayQuizStep() {
+        return new StepBuilder("todayQuizStep", jobRepository)
+                .tasklet(todayQuizTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet todayQuizTasklet() {
+        return (contribution, chunkContext) -> {
+            todayQuizBatchService.initializeData();
+            return null;
+        };
+    }
+}

--- a/module-batch/src/main/java/com/codingbottle/domain/quiz/scheduler/TodayQuizScheduler.java
+++ b/module-batch/src/main/java/com/codingbottle/domain/quiz/scheduler/TodayQuizScheduler.java
@@ -1,0 +1,28 @@
+package com.codingbottle.domain.quiz.scheduler;
+
+import com.codingbottle.domain.quiz.job.TodayQuizJobLauncher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TodayQuizScheduler {
+    private final JobLauncher jobLauncher;
+    private final TodayQuizJobLauncher todayQuizJobLauncher;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void run() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+        jobLauncher.run(todayQuizJobLauncher.todayQuizJob(),
+                new JobParametersBuilder()
+                        .addLong("time", System.currentTimeMillis())
+                        .toJobParameters()
+        );
+    }
+}

--- a/module-batch/src/main/java/com/codingbottle/domain/quiz/service/TodayQuizBatchService.java
+++ b/module-batch/src/main/java/com/codingbottle/domain/quiz/service/TodayQuizBatchService.java
@@ -1,0 +1,18 @@
+package com.codingbottle.domain.quiz.service;
+
+import com.codingbottle.redis.domain.quiz.service.TodayQuizRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TodayQuizBatchService {
+    private final TodayQuizRedisService todayQuizRedisService;
+
+    public void initializeData() {
+        todayQuizRedisService.initializeData();
+        log.info("오늘의 퀴즈 사용자 초기화 완료");
+    }
+}

--- a/module-batch/src/main/java/com/codingbottle/domain/weather/job/WeatherJobLauncher.java
+++ b/module-batch/src/main/java/com/codingbottle/domain/weather/job/WeatherJobLauncher.java
@@ -2,7 +2,6 @@ package com.codingbottle.domain.weather.job;
 
 import com.codingbottle.domain.weather.service.WeatherBatchService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -14,7 +13,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
-@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class WeatherJobLauncher {

--- a/module-batch/src/main/java/com/codingbottle/domain/weather/service/WeatherBatchService.java
+++ b/module-batch/src/main/java/com/codingbottle/domain/weather/service/WeatherBatchService.java
@@ -33,6 +33,7 @@ public class WeatherBatchService {
     public void setWeather() {
         Arrays.stream(Region.values())
                 .forEach(this::setRegionWeather);
+        log.info("날씨 정보를 업데이트 했습니다.");
     }
 
     private void setRegionWeather(Region region) {

--- a/module-common/src/main/java/com/codingbottle/exception/ApplicationErrorType.java
+++ b/module-common/src/main/java/com/codingbottle/exception/ApplicationErrorType.java
@@ -19,6 +19,7 @@ public enum ApplicationErrorType {
     //403
     EXPIRED_FIREBASE_TOKEN(HttpStatus.FORBIDDEN, "Firebase 토큰이 만료되었습니다."),
     ALREADY_SOLVED_QUIZ(HttpStatus.FORBIDDEN, "이미 푼 문제입니다."),
+    ALREADY_SOLVED_TODAY_QUIZ(HttpStatus.BAD_REQUEST, "이미 오늘의 퀴즈를 푸셨습니다."),
     //404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),

--- a/module-infra/src/main/java/com/codingbottle/redis/domain/quiz/config/TodayQuizRedisConfig.java
+++ b/module-infra/src/main/java/com/codingbottle/redis/domain/quiz/config/TodayQuizRedisConfig.java
@@ -1,0 +1,28 @@
+package com.codingbottle.redis.domain.quiz.config;
+
+import com.codingbottle.redis.config.RedisConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories(redisTemplateRef = "todayQuizRedisTemplate")
+public class TodayQuizRedisConfig extends RedisConfig {
+    @Bean
+    public RedisConnectionFactory todayQuizRedisConnectionFactory() {
+        return createLettuceConnectionFactory(5);
+    }
+
+    @Bean
+    public RedisTemplate<Long, Boolean> todayQuizRedisTemplate() {
+        RedisTemplate<Long, Boolean> template = new RedisTemplate<>();
+        template.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setConnectionFactory(todayQuizRedisConnectionFactory());
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/module-infra/src/main/java/com/codingbottle/redis/domain/quiz/service/TodayQuizRedisService.java
+++ b/module-infra/src/main/java/com/codingbottle/redis/domain/quiz/service/TodayQuizRedisService.java
@@ -1,0 +1,33 @@
+package com.codingbottle.redis.domain.quiz.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class TodayQuizRedisService {
+    private final RedisTemplate<Long, Boolean> todayQuizRedisTemplate;
+
+    public boolean isAlreadySolved(Long userId) {
+        return Boolean.TRUE.equals(todayQuizRedisTemplate.opsForSet().isMember(userId, true));
+    }
+
+    public void setSolved(Long userId) {
+        todayQuizRedisTemplate.opsForSet().add(userId, true);
+    }
+
+    public void initializeData() {
+        try {
+            Objects.requireNonNull(todayQuizRedisTemplate.getConnectionFactory())
+                    .getConnection()
+                    .serverCommands()
+                    .flushDb();
+        } catch (Exception e) {
+            throw new RuntimeException("오늘의 퀴즈 레디스 초기화에 실패했습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## :sparkles: 이슈 번호: #113 #109

## :bulb: 상세 내용:
- 기존에는 오늘의 퀴즈를 조회할 때 따로 검증 로직이 없었다. 그래서 이미 사용자가 오늘의 퀴즈를 풀었으면 또 풀지못하도록 검증 로직을 추가하였다.
- 오늘의 퀴즈를 처음 푼 사용자가 퀴즈를 정답 유무에 상관없이 결과를 서버에 보내면 서버는 해당 사용자가 오늘의 문제를 처음 풀었으면 더 오늘의 퀴즈를 조회하지 못하도록 Redis에 사용자를 저장해놓는다.
- 사용자가 오늘의 퀴즈를 풀었는데도 조회를 요청하면 잘못된 요청이라고 반환한다.
- 자정마다 Redis를 초기화하여 다시 오늘의 퀴즈를 조회할 수 있도록 Batch 작업을 추가하였다.
- 또한 퀴즈 타입에 따라 점수를 차등 부여하도록 수정하였다.
- 추후에 오답, 오늘의 퀴즈, 보통 풀기를 하나의 API로 통합할 예정

