### PR TITLE
오늘의 퀴즈, 일반 퀴즈, 오답 퀴즈를 하나의 API로 통합

### DIFF
--- a/module-api/src/main/java/com/codingbottle/domain/quiz/controller/UserQuizController.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/controller/UserQuizController.java
@@ -18,11 +18,6 @@ public class UserQuizController implements UserQuizApi {
     private final UserQuizService userQuizService;
 
     @Override
-    public List<QuizResponse> getWrongQuizzes(@AuthenticationPrincipal User user) {
-        return userQuizService.findRandomWrongQuizzesByUser(user);
-    }
-
-    @Override
     public String quizStatusPut(Long id,
                                 QuizStatusRequest quizStatusRequest,
                                 @AuthenticationPrincipal User user) {

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/model/Type.java
@@ -7,21 +7,28 @@ import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 public enum Type {
-    TODAY(10){
+    TODAY(20){
         @Override
         public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
-            return quizRepository.findRandomQuizzes(user, 3);
+            return quizRepository.findRandomTodayQuizzes(user, 3);
         }
     },
-    NORMAL(5){
+    NORMAL(10){
+        @Override
+        public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
+            return quizRepository.findRandomQuizzes(user, 10);
+        }
+    },
+    WRONG(5){
         @Override
         public List<Quiz> getQuizzes(User user, QuizQueryRepository quizRepository) {
             return quizRepository.findRandomWrongQuizzes(user, 10);
         }
-    };
+    }
+    ;
 
-    @Getter
     final int score;
 
     Type(int score) {

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/restapi/QuizApi.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/restapi/QuizApi.java
@@ -19,10 +19,10 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/quiz")
 public interface QuizApi {
-    @Operation(summary = "퀴즈 목록 조회", description = "Type에 맞는 퀴즈 목록을 조회합니다. (오늘의 퀴즈를 이미 푼 사용자는 에러 메시지가 반환됩니다.")
+    @Operation(summary = "퀴즈 목록 조회", description = "Type에 맞는 퀴즈 목록을 조회합니다. 오늘의 퀴즈를 이미 푼 사용자는 에러 메시지가 반환됩니다. 만약 문제가 존재하지 않는다면 빈 배열이 반환됩니다.")
     @GetMapping
     List<QuizResponse> getQuizList(
             User user,
-            @RequestParam(value = "type") @Parameter(description = "퀴즈 타입을 URL 파라미터로 지정해서 요청하세요. (TODAY, NORMAL)") Type type
+            @RequestParam(value = "type") @Parameter(description = "퀴즈 타입을 URL 파라미터로 지정해서 요청하세요. (TODAY, NORMAL, WRONG)") Type type
     );
 }

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/restapi/UserQuizApi.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/restapi/UserQuizApi.java
@@ -18,11 +18,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/quiz/users")
 public interface UserQuizApi {
-    @Operation(summary = "오답 퀴즈 조회", description = "사용자의 오답 퀴즈를 조회합니다.")
-    @GetMapping("/wrong")
-    List<QuizResponse> getWrongQuizzes(
-            User user
-    );
 
     @Operation(summary = "퀴즈 결과 저장 요청", description = "사용자의 퀴즈 결과를 저장합니다.")
     @PutMapping("/{id}/result")

--- a/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
+++ b/module-api/src/main/java/com/codingbottle/domain/quiz/service/UserQuizService.java
@@ -1,6 +1,5 @@
 package com.codingbottle.domain.quiz.service;
 
-import com.codingbottle.domain.quiz.model.QuizResponse;
 import com.codingbottle.domain.quiz.model.Type;
 import com.codingbottle.domain.user.entity.User;
 import com.codingbottle.domain.user.event.UpdateUserInfoRankCacheEvent;
@@ -21,9 +20,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -38,17 +34,6 @@ public class UserQuizService {
     public void handleUserUpdate(UpdateUserInfoRankCacheEvent event) {
         int score = quizRankRedisService.removeUserWithScore(UserInfo.of(event.getUser().getId(), event.getUser().getNickname()));
         quizRankRedisService.addScore(UserInfo.of(event.getUser().getId(), event.getUserUpdateInfo().nickname()), score);
-    }
-
-    public List<QuizResponse> findRandomWrongQuizzesByUser(User user) {
-        List<Quiz> randomWrongQuizzes = userQuizQueryRepository.findRandomWrongQuizzesByUser(user);
-
-        if (randomWrongQuizzes.isEmpty()) {
-            throw new ApplicationErrorException(ApplicationErrorType.NOT_EXIT_WRONG_ANSWER);
-        }
-        return randomWrongQuizzes.stream()
-                .map(QuizResponse::from)
-                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/module-api/src/test/java/com/codingbottle/docs/util/RestDocsTest.java
+++ b/module-api/src/test/java/com/codingbottle/docs/util/RestDocsTest.java
@@ -1,5 +1,6 @@
 package com.codingbottle.docs.util;
 
+import com.codingbottle.common.security.WithAuthUser;
 import com.codingbottle.docs.config.RestDocsConfig;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,6 +19,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @Disabled
+@WithAuthUser
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
 @Import(RestDocsConfig.class)

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/QuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/QuizControllerTest.java
@@ -7,7 +7,6 @@ import com.codingbottle.domain.quiz.model.Type;
 import com.codingbottle.domain.quiz.service.QuizService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
@@ -26,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("QuizController 테스트")
 @ContextConfiguration(classes = QuizController.class)
-@WebMvcTest(value = QuizController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WebMvcTest(value = QuizController.class)
 class QuizControllerTest extends RestDocsTest {
     @MockBean
     private QuizService quizService;
@@ -60,5 +59,29 @@ class QuizControllerTest extends RestDocsTest {
                                 fieldWithPath("[].image.id").description("퀴즈 이미지 id").type("Number"),
                                 fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url")
                 )));
+    }
+
+    @Test
+    @DisplayName("일반 퀴즈를 조회한다")
+    void get_normal_quiz() throws Exception {
+        //given
+        given(quizService.findByType(any(User.class), any(Type.class))).willReturn(List.of(QuizResponse.from(퀴즈1), QuizResponse.from(퀴즈2)));
+        //when & then
+        mvc.perform(get(REQUEST_URL)
+                        .queryParam("type", "NORMAL")
+                        .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("오답 퀴즈를 조회한다")
+    void get_wrong_quiz() throws Exception {
+        //given
+        given(quizService.findByType(any(User.class), any(Type.class))).willReturn(List.of(QuizResponse.from(퀴즈1), QuizResponse.from(퀴즈2)));
+        //when & then
+        mvc.perform(get(REQUEST_URL)
+                        .queryParam("type", "WRONG")
+                        .header("Authorization", "Bearer FirebaseToken"))
+                .andExpect(status().isOk());
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/controller/UserQuizControllerTest.java
@@ -37,31 +37,6 @@ class UserQuizControllerTest extends RestDocsTest {
     private static final String REQUEST_URL = "/api/v1/quiz/users";
 
     @Test
-    @DisplayName("사용자 오답 퀴즈를 조회한다")
-    void get_wrong_quizzes() throws Exception {
-        //given
-        given(userQuizService.findRandomWrongQuizzesByUser(any(User.class))).willReturn(List.of(QuizResponse.from(퀴즈1), QuizResponse.from(퀴즈2)));
-        //when & then
-        mvc.perform(get(REQUEST_URL + "/wrong")
-                .header("Authorization", "Bearer FirebaseToken"))
-                .andExpect(status().isOk())
-                .andDo(document("wrong-answer-list",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        getAuthorizationHeader(),
-                        responseFields(
-                                fieldWithPath("[].id").description("퀴즈 ID").type("Number"),
-                                fieldWithPath("[].question").description("퀴즈 질문"),
-                                fieldWithPath("[].answer").description("퀴즈 정답"),
-                                fieldWithPath("[].quizType").description("퀴즈 타입 (MultipleChoice / OX)"),
-                                fieldWithPath("[].choices.*").description("퀴즈 보기 (객관식은 4개, OX는 2개)").type("Map"),
-                                fieldWithPath("[].image").description("퀴즈 이미지 (null일 수 있음)").optional(),
-                                fieldWithPath("[].image.id").description("퀴즈 이미지 id").type("Number"),
-                                fieldWithPath("[].image.imageUrl").description("퀴즈 이미지 url")
-                        )));
-    }
-
-    @Test
     @DisplayName("사용자 퀴즈 정보를 조회한다")
     void get_user_quiz_info() throws Exception {
         //given

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/QuizServiceTest.java
@@ -37,7 +37,7 @@ class QuizServiceTest {
     @DisplayName("일반 퀴즈를 조회한다")
     void findByNormalQuiz() {
         //given
-        given(quizRepository.findRandomWrongQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
+        given(quizRepository.findRandomQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
         //when
         List<QuizResponse> quizzes = quizService.findByType(유저1, Type.NORMAL);
         //then
@@ -48,7 +48,7 @@ class QuizServiceTest {
     @DisplayName("오늘의 퀴즈를 조회한다")
     void findByTodayQuiz(){
         //given
-        given(quizRepository.findRandomQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
+        given(quizRepository.findRandomTodayQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
         //when
         List<QuizResponse> quizzes = quizService.findByType(유저1, Type.TODAY);
         //then
@@ -63,5 +63,27 @@ class QuizServiceTest {
         //when & then
         assertThatThrownBy(() -> quizService.findByType(유저1, Type.TODAY))
                 .isInstanceOf(ApplicationErrorException.class);
+    }
+
+    @Test
+    @DisplayName("퀴즈 조회시 퀴즈가 없으면 빈 리스트를 반환한다")
+    void findByTypeAndEmptyQuiz(){
+        //given
+        given(quizRepository.findRandomQuizzes(any(User.class), anyInt())).willReturn(List.of());
+        //when
+        List<QuizResponse> quizzes = quizService.findByType(유저1, Type.NORMAL);
+        //then
+        assertThat(quizzes.size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("오답 퀴즈를 조회한다")
+    void findByWrongQuiz(){
+        //given
+        given(quizRepository.findRandomWrongQuizzes(any(User.class), anyInt())).willReturn(List.of(퀴즈1, 퀴즈2));
+        //when
+        List<QuizResponse> quizzes = quizService.findByType(유저1, Type.WRONG);
+        //then
+        assertThat(quizzes.size()).isEqualTo(2);
     }
 }

--- a/module-api/src/test/java/com/codingbottle/domain/quiz/service/UserQuizServiceTest.java
+++ b/module-api/src/test/java/com/codingbottle/domain/quiz/service/UserQuizServiceTest.java
@@ -1,6 +1,5 @@
 package com.codingbottle.domain.quiz.service;
 
-import com.codingbottle.domain.quiz.model.QuizResponse;
 import com.codingbottle.domain.quiz.model.UserQuizInfo;
 import com.codingbottle.domain.quiz.repo.UserQuizQueryRepository;
 import com.codingbottle.domain.quiz.repo.UserQuizSimpleJPARepository;
@@ -14,7 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.codingbottle.fixture.DomainFixture.*;
@@ -122,27 +120,6 @@ class UserQuizServiceTest {
         String status = userQuizService.updateQuizStatus(퀴즈1.getId(), 퀴즈_정답_요청, 유저1);
         //then
         assertThat(status).isEqualTo("CORRECT");
-    }
-
-    @Test
-    @DisplayName("틀린 퀴즈가 없으면 예외를 던진다")
-    void if_there_is_no_wrong_answer_then_throw_exception() {
-        //given
-        given(userQuizQueryRepository.findRandomWrongQuizzesByUser(any())).willReturn(List.of());
-        //when & then
-        assertThatThrownBy(() -> userQuizService.findRandomWrongQuizzesByUser(유저1))
-                .isInstanceOf(ApplicationErrorException.class);
-    }
-
-    @Test
-    @DisplayName("틀린 퀴즈 중 랜덤으로 퀴즈를 조회한다")
-    void find_random_wrong_quizzes() {
-        //given
-        given(userQuizQueryRepository.findRandomWrongQuizzesByUser(any())).willReturn(List.of(퀴즈1, 퀴즈2));
-        //when
-        List<QuizResponse> quizzes = userQuizService.findRandomWrongQuizzesByUser(유저1);
-        //then
-        assertThat(quizzes).isEqualTo(List.of(QuizResponse.from(퀴즈1), QuizResponse.from(퀴즈2)));
     }
 
     @Test

--- a/module-domain/src/main/java/com/codingbottle/domain/quiz/repo/QuizQueryRepository.java
+++ b/module-domain/src/main/java/com/codingbottle/domain/quiz/repo/QuizQueryRepository.java
@@ -19,23 +19,32 @@ public class QuizQueryRepository {
     private final QQuiz qQuiz = QQuiz.quiz;
     private final QUserQuiz qUserQuiz = QUserQuiz.userQuiz;
 
-    public List<Quiz> findRandomWrongQuizzes(User user, int limit) {
+    public List<Quiz> findRandomQuizzes(User user, int limit) {
         return jpaQueryFactory.selectFrom(qQuiz)
                 .leftJoin(qUserQuiz)
                 .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user))
-                .where(qUserQuiz.quizStatus.eq(QuizStatus.WRONG)
+                .where(qUserQuiz.quizStatus.isNull())
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<Quiz> findRandomTodayQuizzes(User user, int limit) {
+        return jpaQueryFactory.selectFrom(qQuiz)
+                .leftJoin(qUserQuiz)
+                .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user))
+                .where(qUserQuiz.quizStatus.ne(QuizStatus.CORRECT)
                         .or(qUserQuiz.quizStatus.isNull()))
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .limit(limit)
                 .fetch();
     }
 
-    public List<Quiz> findRandomQuizzes(User user, int limit) {
-        return jpaQueryFactory.selectFrom(qQuiz)
-                .leftJoin(qUserQuiz)
-                .on(qQuiz.eq(qUserQuiz.quiz), qUserQuiz.user.eq(user))
-                .where(qUserQuiz.quizStatus.ne(QuizStatus.CORRECT)
-                        .or(qUserQuiz.quizStatus.isNull()))
+    public List<Quiz> findRandomWrongQuizzes(User user, int limit) {
+        return jpaQueryFactory.select(qUserQuiz.quiz)
+                .from(qUserQuiz)
+                .where(qUserQuiz.user.eq(user)
+                        .and(qUserQuiz.quizStatus.eq(QuizStatus.WRONG)))
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .limit(limit)
                 .fetch();

--- a/module-domain/src/test/java/com/codingbottle/domain/quiz/repo/QuizQueryRepositoryTest.java
+++ b/module-domain/src/test/java/com/codingbottle/domain/quiz/repo/QuizQueryRepositoryTest.java
@@ -43,7 +43,7 @@ class QuizQueryRepositoryTest {
     @DisplayName("랜덤으로 퀴즈를 조회한다")
     void find_random_quizzes() {
         //when
-        List<Quiz> randomQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, 3);
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, 3);
         //then
         assertThat(randomQuizzes).hasSize(2);
     }
@@ -54,7 +54,7 @@ class QuizQueryRepositoryTest {
         //given
         userQuizSimpleJPARepository.save(유저1_퀴즈1);
         //when
-        List<Quiz> randomQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, 3);
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, 3);
         //then
         assertThat(randomQuizzes).hasSize(1);
     }
@@ -64,8 +64,19 @@ class QuizQueryRepositoryTest {
     @DisplayName("랜덤으로 퀴즈를 조회하는데 limit을 지정할 수 있다.")
     void find_random_quizzes_limit(int limit, int expectedSize) {
         //when
-        List<Quiz> randomQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, limit);
+        List<Quiz> randomQuizzes = quizQueryRepository.findRandomQuizzes(유저, limit);
         //then
         assertThat(randomQuizzes).hasSize(expectedSize);
+    }
+
+    @Test
+    @DisplayName("오답 퀴즈를 조회한다")
+    void find_random_wrong_quizzes() {
+        //given
+        userQuizSimpleJPARepository.save(유저1_오답1);
+        //when
+        List<Quiz> randomWrongQuizzes = quizQueryRepository.findRandomWrongQuizzes(유저, 3);
+        //then
+        assertThat(randomWrongQuizzes).hasSize(1);
     }
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #115

## :bulb: 상세 내용:
- 기존의 오답 조회 API를 삭제하고 퀴즈 조회시에 Type을 추가하여 하나의 API로 통합
- 테스트 작성 및 API 문서 최신화

