### PR TITLE
게시글 전체 조회(페이지네이션) 시 image를 fetch join하도록 query 변경

### DIFF
--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -26,11 +26,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         default_batch_fetch_size: ${chunkSize:100}
-        jdbc.batch_size: 10
+        jdbc.batch_size: 100
         order_inserts: true
         order_updates: true
         format_sql: true
-    show-sql: true
     open-in-view: false
   security:
     user:
@@ -88,11 +87,9 @@ job-setting:
 
 logging:
   level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql: trace
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql: trace
+
 
 ---
 spring:

--- a/module-common/src/main/java/com/codingbottle/aop/ExeTimer.java
+++ b/module-common/src/main/java/com/codingbottle/aop/ExeTimer.java
@@ -1,0 +1,11 @@
+package com.codingbottle.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExeTimer {
+}

--- a/module-common/src/main/java/com/codingbottle/aop/ExeTimerImpl.java
+++ b/module-common/src/main/java/com/codingbottle/aop/ExeTimerImpl.java
@@ -1,0 +1,30 @@
+package com.codingbottle.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Aspect
+@Component
+public class ExeTimerImpl {
+    @Pointcut("@annotation(com.codingbottle.aop.ExeTimer)")
+    private void timer() {}
+
+    @Around("timer()")
+    public Object AssumeExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        Object proceed = joinPoint.proceed();
+        stopWatch.stop();
+        long totalTimeMillis = stopWatch.getTotalTimeMillis();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String methodName = signature.getMethod().getName();
+        System.out.println("메서드 이름 : " + methodName);
+        System.out.println("수행 시간 : " + totalTimeMillis + "ms");
+        return proceed;
+    }
+}

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':module-common')
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/module-domain/src/main/java/com/codingbottle/domain/post/entity/Post.java
+++ b/module-domain/src/main/java/com/codingbottle/domain/post/entity/Post.java
@@ -32,7 +32,7 @@ public class Post extends BaseEntity implements Serializable {
     private List<String> hashtags = new ArrayList<>(5);
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/module-domain/src/main/java/com/codingbottle/domain/post/repo/PostQueryRepository.java
+++ b/module-domain/src/main/java/com/codingbottle/domain/post/repo/PostQueryRepository.java
@@ -1,5 +1,6 @@
 package com.codingbottle.domain.post.repo;
 
+import com.codingbottle.domain.image.entity.QImage;
 import com.codingbottle.domain.post.entity.Post;
 import com.codingbottle.domain.post.entity.QPost;
 import com.querydsl.core.types.Order;
@@ -16,6 +17,7 @@ import java.util.List;
 public class PostQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
     private final QPost post = QPost.post;
+    private final QImage image = QImage.image;
 
     public List<Post> searchByKeyword(String keyword) {
         return jpaQueryFactory.selectFrom(post)
@@ -25,6 +27,7 @@ public class PostQueryRepository {
 
     public List<Post> finAll(Pageable pageable) {
         return jpaQueryFactory.selectFrom(post)
+                .leftJoin(post.image, image).fetchJoin()
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .orderBy(new OrderSpecifier[]{new OrderSpecifier<>(Order.DESC, post.createdTime)})


### PR DESCRIPTION
## :sparkles: 이슈 번호: #119


## :bulb: 상세 내용:
- 기존의 batch size를 이용하여 지연 로딩시에 IN 문법을 통해 데이터를 조회하는 방식에서 Image 엔티티만 fetch join하여 즉시 로딩하도록 변경
- 응답 시간 측정 AOP 추가
- https://velog.io/@qwe916/JPA-Betch-Size%EC%97%90-%EB%94%B0%EB%A5%B8-null-%EA%B0%92-%EB%B0%94%EC%9D%B8%EB%94%A9

